### PR TITLE
fix bug and rollback libs after libcheck

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21235,7 +21235,7 @@ class Tagger {
     tag(revision, channel, resources, tagPrefix) {
         return __awaiter(this, void 0, void 0, function* () {
             const { owner, repo } = github_1.context.repo;
-            if (github_1.context.eventName.includes('pull_request')) {
+            if (github_1.context.eventName && github_1.context.eventName.includes('pull_request')) {
                 return;
             }
             const content = this._build(owner, repo, process.env['GITHUB_SHA'], revision, channel, resources, tagPrefix);

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -20677,6 +20677,25 @@ function wrappy (fn, cb) {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -20690,6 +20709,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CheckLibrariesAction = void 0;
 const core_1 = __nccwpck_require__(2186);
 const github_1 = __nccwpck_require__(5438);
+const exec = __importStar(__nccwpck_require__(1514));
 const services_1 = __nccwpck_require__(720);
 class CheckLibrariesAction {
     constructor() {
@@ -20743,6 +20763,7 @@ to your PR branch.
                         body: this.getCommentBody(status),
                     });
                 }
+                yield exec.exec('git', ['checkout', 'HEAD', '--', 'lib']);
                 if (!status.ok && this.outcomes.fail) {
                     (0, core_1.setFailed)('Charmcraft libraries are not up to date.');
                 }
@@ -21344,7 +21365,7 @@ class Tagger {
     tag(revision, channel, resources, tagPrefix) {
         return __awaiter(this, void 0, void 0, function* () {
             const { owner, repo } = github_1.context.repo;
-            if (github_1.context.eventName.includes('pull_request')) {
+            if (github_1.context.eventName && github_1.context.eventName.includes('pull_request')) {
                 return;
             }
             const content = this._build(owner, repo, process.env['GITHUB_SHA'], revision, channel, resources, tagPrefix);

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -20709,6 +20709,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.CheckLibrariesAction = void 0;
 const core_1 = __nccwpck_require__(2186);
 const github_1 = __nccwpck_require__(5438);
+const fs = __importStar(__nccwpck_require__(7147));
 const exec = __importStar(__nccwpck_require__(1514));
 const services_1 = __nccwpck_require__(720);
 class CheckLibrariesAction {
@@ -20752,6 +20753,10 @@ to your PR branch.
         return __awaiter(this, void 0, void 0, function* () {
             try {
                 process.chdir(this.charmPath);
+                if (!fs.existsSync('./lib')) {
+                    (0, core_1.warning)('No lib folder detected. Skipping action.');
+                    return;
+                }
                 yield this.snap.install('charmcraft', this.channel);
                 const status = yield this.charmcraft.hasDriftingLibs();
                 // we do this using includes to catch both `pull_request` and `pull_request_target`

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21305,7 +21305,7 @@ class Tagger {
     tag(revision, channel, resources, tagPrefix) {
         return __awaiter(this, void 0, void 0, function* () {
             const { owner, repo } = github_1.context.repo;
-            if (github_1.context.eventName.includes('pull_request')) {
+            if (github_1.context.eventName && github_1.context.eventName.includes('pull_request')) {
                 return;
             }
             const content = this._build(owner, repo, process.env['GITHUB_SHA'], revision, channel, resources, tagPrefix);

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21310,7 +21310,7 @@ class Tagger {
     tag(revision, channel, resources, tagPrefix) {
         return __awaiter(this, void 0, void 0, function* () {
             const { owner, repo } = github_1.context.repo;
-            if (github_1.context.eventName.includes('pull_request')) {
+            if (github_1.context.eventName && github_1.context.eventName.includes('pull_request')) {
                 return;
             }
             const content = this._build(owner, repo, process.env['GITHUB_SHA'], revision, channel, resources, tagPrefix);

--- a/src/actions/check-libraries/check-libraries.ts
+++ b/src/actions/check-libraries/check-libraries.ts
@@ -1,8 +1,8 @@
-import { error, getInput, setFailed } from '@actions/core';
+import { error, getInput, setFailed, warning } from '@actions/core';
 import { context, getOctokit } from '@actions/github';
 import { Context } from '@actions/github/lib/context';
 import { GitHub } from '@actions/github/lib/utils';
-
+import * as fs from 'fs';
 import * as exec from '@actions/exec';
 
 import { Charmcraft, LibStatus, Snap } from '../../services';
@@ -42,6 +42,10 @@ export class CheckLibrariesAction {
   async run() {
     try {
       process.chdir(this.charmPath!);
+      if (!fs.existsSync('./lib')) {
+        warning('No lib folder detected. Skipping action.');
+        return;
+      }
       await this.snap.install('charmcraft', this.channel);
       const status = await this.charmcraft.hasDriftingLibs();
       // we do this using includes to catch both `pull_request` and `pull_request_target`
@@ -53,7 +57,6 @@ export class CheckLibrariesAction {
           body: this.getCommentBody(status),
         });
       }
-
       await exec.exec('git', ['checkout', 'HEAD', '--', 'lib']);
 
       if (!status.ok && this.outcomes.fail) {

--- a/src/actions/check-libraries/check-libraries.ts
+++ b/src/actions/check-libraries/check-libraries.ts
@@ -3,6 +3,8 @@ import { context, getOctokit } from '@actions/github';
 import { Context } from '@actions/github/lib/context';
 import { GitHub } from '@actions/github/lib/utils';
 
+import * as exec from '@actions/exec';
+
 import { Charmcraft, LibStatus, Snap } from '../../services';
 import { Outcomes, Tokens } from '../../types';
 
@@ -51,6 +53,9 @@ export class CheckLibrariesAction {
           body: this.getCommentBody(status),
         });
       }
+
+      await exec.exec('git', ['checkout', 'HEAD', '--', 'lib']);
+
       if (!status.ok && this.outcomes.fail) {
         setFailed('Charmcraft libraries are not up to date.');
       }

--- a/src/services/tagging/tagging.ts
+++ b/src/services/tagging/tagging.ts
@@ -19,7 +19,7 @@ class Tagger {
     tagPrefix?: string
   ) {
     const { owner, repo } = context.repo;
-    if (context.eventName.includes('pull_request')) {
+    if (context.eventName && context.eventName.includes('pull_request')) {
       return;
     }
     const content = this._build(


### PR DESCRIPTION
This PR counters a side effect of the libchecker action that would lead to the charm being published with the latest libraries if the libschecker and the upload charm action where used as steps in the same job rather than split across multiple jobs. In addition, the libchecker action will not execute if the charm has no lib folder. 

Further, the PR fixes a possible bug that likely would ever occur in testing scenarios, where the event name of our context would be null.