### PR TITLE
Sets charmcraft pack as root

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21666,8 +21666,8 @@ class Charmcraft {
     }
     pack() {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['pack', '--destructive-mode', '--quiet'];
-            yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
+            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }
     upload(channel, flags) {

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21801,8 +21801,8 @@ class Charmcraft {
     }
     pack() {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['pack', '--destructive-mode', '--quiet'];
-            yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
+            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }
     upload(channel, flags) {

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21736,8 +21736,8 @@ class Charmcraft {
     }
     pack() {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['pack', '--destructive-mode', '--quiet'];
-            yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
+            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }
     upload(channel, flags) {

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21763,8 +21763,8 @@ class Charmcraft {
     }
     pack() {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['pack', '--destructive-mode', '--quiet'];
-            yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
+            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }
     upload(channel, flags) {

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -175,8 +175,8 @@ class Charmcraft {
   }
 
   async pack() {
-    const args = ['pack', '--destructive-mode', '--quiet'];
-    await exec('charmcraft', args, this.execOptions);
+    const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+    await exec('sudo', args, this.execOptions);
   }
 
   async upload(channel: string, flags: string[]): Promise<string> {


### PR DESCRIPTION
If a charm has dependencies that would have to be installed through ``apt-get`` (defined in ``charmcraft.yaml``, under build-packages), the ``upload-charm`` action fails because it tries to build charm and install these dependencies without the necessary privileges.

Fixes: https://github.com/canonical/charming-actions/issues/34