### PR TITLE
feat: use `charmcraft` structured status output for `release-charm`

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21547,16 +21547,6 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
-function checkIfIsBase(baseRelease, base) {
-    const { name, channel: baseChannel, architecture } = base;
-    if (baseRelease.base === null) {
-        // This release has no base.  Nothing is here
-        return false;
-    }
-    return (baseRelease.base.name === name &&
-        baseRelease.base.channel === baseChannel &&
-        baseRelease.base.architecture === architecture);
-}
 function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
@@ -21566,23 +21556,6 @@ function getSaferChannel(channel) {
         return orderedChannels[iLessRisky];
     }
     return '';
-}
-function getTrackByName(trackArray, track) {
-    const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
-    if (i === -1) {
-        throw new Error(`No track with name ${track}`);
-    }
-    const trackObj = trackArray[i];
-    return { i, track: trackObj };
-}
-function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
-    // Accepts an array of {base: base_spec, releases: [releaseOnChannelA, releaseOnChannelB, ...]} objects,
-    // returning the releasOnChannelX releases array corresponding to the specified base
-    //
-    // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
-    const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
-    const releasesArray = baseReleaseArray[i].releases;
-    return { i, releases: releasesArray };
 }
 function getReleaseFromReleaseArrayByChannel(releases, channel) {
     const i = releases.findIndex((release) => release.channel === channel);
@@ -21847,24 +21820,30 @@ class Charmcraft {
             throw new Error(`No track with name ${track}`);
         });
     }
-    getRevisionInfoFromChannelJson(charm, track, channel, base) {
+    getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
             const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(channel)) {
-                throw new Error(`Provided channel ${channel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
+            if (!acceptedChannels.includes(targetChannel)) {
+                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
-            const { track: trackObj } = getTrackByName(charmcraftStatus, track);
-            // const trackObj = charmcraftStatus.filter((obj: any) => obj.track === track)
-            // const channelWithSpecifiedBase = trackObj.filter((releaseChannel: any) => releaseChannel.base.name === base.name && releaseChannel.base.channel === base.channel && releaseChannel.base.architecture === base.architecture)
-            // const targetRelease = channelWithSpecifiedBase.releases.filter((release: any) => release.channel === channel)
-            const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
-            if (releasesArray === null) {
-                throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
             }
-            // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
-            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            const channelIndex = charmcraftStatus[trackIndex].channels.findIndex((channel) => channel.base &&
+                channel.base.name === targetBase.name &&
+                channel.base.channel === targetBase.channel &&
+                channel.base.architecture === targetBase.architecture);
+            if (channelIndex === -1) {
+                throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
+            }
+            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === targetChannel);
+            if (releaseIndex === -1) {
+                throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
+            }
+            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(charmcraftStatus[trackIndex].channels[channelIndex].releases, targetChannel);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
             const resourceInfoArray = [];

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21561,22 +21561,18 @@ function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
     const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
     const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    // console.log(`found less risky channel is at index ${iLessRisky}`);
     if (iLessRisky >= 0) {
         return orderedChannels[iLessRisky];
     }
     return '';
 }
 function getTrackByName(trackArray, track) {
-    // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
     const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
     if (i === -1) {
         throw new Error(`No track with name ${track}`);
     }
     const trackObj = trackArray[i];
-    // console.log(`Found track ${track} at index ${i}: ${JSON.stringify(trackObj)}`);
     return { i, track: trackObj };
 }
 function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
@@ -21586,14 +21582,11 @@ function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
     // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
     const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
     const releasesArray = baseReleaseArray[i].releases;
-    // console.log(`Found releases ${base} at index ${i}: ${JSON.stringify(releasesArray)}`);
     return { i, releases: releasesArray };
 }
 function getReleaseFromReleaseArrayByChannel(releases, channel) {
-    // console.log(`releases: ${JSON.stringify(releases)}`)
     const i = releases.findIndex((release) => release.channel === channel);
     const releaseObj = releases[i];
-    // console.log(`Found release for channel ${channel} at index ${i}: ${JSON.stringify(releaseObj)}`);
     return { i, release: releaseObj };
 }
 function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
@@ -21620,9 +21613,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     //
     // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
     // an error for this case.  This situation is identified by `release.status == closed`.
-    // console.log(`releaseArray: ${JSON.stringify(releases)}`);
     const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-    // console.log(`release: ${JSON.stringify(release)}`);
     if (release.status === 'open') {
         // Release exists.  Return it
         return { i, release };
@@ -21864,27 +21855,26 @@ class Charmcraft {
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
-            // console.log(`charmcraftStatus: ${charmcraftStatus}`);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
+            // const trackObj = charmcraftStatus.filter((obj: any) => obj.track === track)
+            // const channelWithSpecifiedBase = trackObj.filter((releaseChannel: any) => releaseChannel.base.name === base.name && releaseChannel.base.channel === base.channel && releaseChannel.base.architecture === base.architecture)
+            // const targetRelease = channelWithSpecifiedBase.releases.filter((release: any) => release.channel === channel)
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {
                 throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
             }
             // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
             const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
-            // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
-            // console.log(`resources: ${JSON.stringify(resources)}`);
             const resourceInfoArray = [];
             for (let i = 0; i < resources.length; i += 1) {
-                // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
                 resourceInfoArray.push({
                     resourceName: resources[i].name,
-                    resourceRev: resources[i].revision,
+                    resourceRev: resources[i].revision.toString(),
                 });
             }
-            return { charmRev: revision, resources: resourceInfoArray };
+            return { charmRev: revision.toString(), resources: resourceInfoArray };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21561,13 +21561,16 @@ function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
     const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+    // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
     const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    if (iLessRisky > 0) {
+    // console.log(`found less risky channel is at index ${iLessRisky}`);
+    if (iLessRisky >= 0) {
         return orderedChannels[iLessRisky];
     }
     return '';
 }
 function getTrackByName(trackArray, track) {
+    // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
     const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
     if (i === -1) {
         throw new Error(`No track with name ${track}`);
@@ -21617,7 +21620,9 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     //
     // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
     // an error for this case.  This situation is identified by `release.status == closed`.
+    // console.log(`releaseArray: ${JSON.stringify(releases)}`);
     const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
+    // console.log(`release: ${JSON.stringify(release)}`);
     if (release.status === 'open') {
         // Release exists.  Return it
         return { i, release };
@@ -21625,6 +21630,10 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     if (release.status === 'tracking') {
         // Pointer to a safer channel.  Return that instead
         const saferChannel = getSaferChannel(channel);
+        if (saferChannel === '') {
+            // no safer channel exists.  Should we throw?
+            throw new Error(`release.status == tracking for channel ${channel}, but no safer channel exists`);
+        }
         return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
     }
     if (release.status === 'closed') {
@@ -21855,6 +21864,7 @@ class Charmcraft {
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
+            // console.log(`charmcraftStatus: ${charmcraftStatus}`);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21547,6 +21547,92 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
+function checkIfIsBase(baseRelease, base) {
+    const { name, channel: baseChannel, architecture } = base;
+    if (baseRelease.base === null) {
+        // This release has no base.  Nothing is here
+        return false;
+    }
+    return (baseRelease.base.name === name &&
+        baseRelease.base.channel === baseChannel &&
+        baseRelease.base.architecture === architecture);
+}
+function getSaferChannel(channel) {
+    // Returns name of the next less risky channel, or an empty string if none exist
+    // standard channel names, from least to most risk
+    const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+    const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
+    if (iLessRisky > 0) {
+        return orderedChannels[iLessRisky];
+    }
+    return '';
+}
+function getTrackByName(trackArray, track) {
+    const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
+    if (i === -1) {
+        throw new Error(`No track with name ${track}`);
+    }
+    const trackObj = trackArray[i];
+    // console.log(`Found track ${track} at index ${i}: ${JSON.stringify(trackObj)}`);
+    return { i, track: trackObj };
+}
+function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
+    // Accepts an array of {base: base_spec, releases: [releaseOnChannelA, releaseOnChannelB, ...]} objects,
+    // returning the releasOnChannelX releases array corresponding to the specified base
+    //
+    // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
+    const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
+    const releasesArray = baseReleaseArray[i].releases;
+    // console.log(`Found releases ${base} at index ${i}: ${JSON.stringify(releasesArray)}`);
+    return { i, releases: releasesArray };
+}
+function getReleaseFromReleaseArrayByChannel(releases, channel) {
+    // console.log(`releases: ${JSON.stringify(releases)}`)
+    const i = releases.findIndex((release) => release.channel === channel);
+    const releaseObj = releases[i];
+    // console.log(`Found release for channel ${channel} at index ${i}: ${JSON.stringify(releaseObj)}`);
+    return { i, release: releaseObj };
+}
+function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
+    // Returns the release in an array of releases for a given channel, handling any null releases
+    //
+    // Some charmhub releases "point" to another release, for example:
+    //    `charmcraft status metacontroller-operator`:
+    //        Track    Base                  Channel                    Version    Revision    Expires at
+    //        latest   ubuntu 20.04 (amd64)  stable                      2          2
+    //                                       candidate                   5          5
+    //                                       beta                        ↑          ↑
+    //                                       edge                       13         13
+    //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
+    //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
+    //        0.3      -                     stable                      -          -
+    //                                       candidate                   -          -
+    //                                       beta                        -          -
+    //                                       edge                        -          -
+    // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
+    // `charmcraft status charmName --format json` returns these pointer releases with
+    // `release.status == tracking` and `release.revision == null`.
+    // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
+    // check candidate).
+    //
+    // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
+    // an error for this case.  This situation is identified by `release.status == closed`.
+    const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
+    if (release.status === 'open') {
+        // Release exists.  Return it
+        return { i, release };
+    }
+    if (release.status === 'tracking') {
+        // Pointer to a safer channel.  Return that instead
+        const saferChannel = getSaferChannel(channel);
+        return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
+    }
+    if (release.status === 'closed') {
+        // No release exists.  Throw
+        throw new Error(`No revision available in channel ${channel}`);
+    }
+    throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
+}
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
@@ -21710,6 +21796,13 @@ class Charmcraft {
             return result.stdout;
         });
     }
+    statusJson(charm) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const parsedObj = JSON.parse(result.stdout);
+            return parsedObj;
+        });
+    }
     getRevisionInfoFromChannel(charm, track, channel) {
         return __awaiter(this, void 0, void 0, function* () {
             // For now we have to parse the `charmcraft status` output this will soon be fixed
@@ -21752,6 +21845,28 @@ class Charmcraft {
                 }
             }
             throw new Error(`No track with name ${track}`);
+        });
+    }
+    getRevisionInfoFromChannel_json(charm, track, channel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
+            if (!acceptedChannels.includes(channel)) {
+                throw new Error(`Provided channel ${channel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
+            }
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const { track: trackObj } = getTrackByName(charmcraftStatus, track);
+            // TODO: make base an input arg
+            const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
+            const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
+            if (releasesArray === null) {
+                throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
+            }
+            // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
+            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            const { revision } = releaseObj;
+            const { resources } = releaseObj;
+            return { charmRev: revision, resources };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21629,7 +21629,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     }
     if (release.status === 'closed') {
         // No release exists.  Throw
-        throw new Error(`No revision available in channel ${channel}`);
+        throw new Error(`No revision available in risk level ${channel}`);
     }
     throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
 }
@@ -21862,9 +21862,19 @@ class Charmcraft {
             }
             // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
             const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
-            return { charmRev: revision, resources };
+            // console.log(`resources: ${JSON.stringify(resources)}`);
+            const resourceInfoArray = [];
+            for (let i = 0; i < resources.length; i += 1) {
+                // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
+                resourceInfoArray.push({
+                    resourceName: resources[i].name,
+                    resourceRev: resources[i].revision,
+                });
+            }
+            return { charmRev: revision, resources: resourceInfoArray };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21847,7 +21847,7 @@ class Charmcraft {
             throw new Error(`No track with name ${track}`);
         });
     }
-    getRevisionInfoFromChannel_json(charm, track, channel) {
+    getRevisionInfoFromChannelJson(charm, track, channel, base) {
         return __awaiter(this, void 0, void 0, function* () {
             const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
             if (!acceptedChannels.includes(channel)) {
@@ -21856,8 +21856,6 @@ class Charmcraft {
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
-            // TODO: make base an input arg
-            const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {
                 throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21547,65 +21547,6 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
-function getSaferChannel(channel) {
-    // Returns name of the next less risky channel, or an empty string if none exist
-    // standard channel names, from least to most risk
-    const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    if (iLessRisky >= 0) {
-        return orderedChannels[iLessRisky];
-    }
-    return '';
-}
-function getReleaseFromReleaseArrayByChannel(releases, channel) {
-    const i = releases.findIndex((release) => release.channel === channel);
-    const releaseObj = releases[i];
-    return { i, release: releaseObj };
-}
-function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
-    // Returns the release in an array of releases for a given channel, handling any null releases
-    //
-    // Some charmhub releases "point" to another release, for example:
-    //    `charmcraft status metacontroller-operator`:
-    //        Track    Base                  Channel                    Version    Revision    Expires at
-    //        latest   ubuntu 20.04 (amd64)  stable                      2          2
-    //                                       candidate                   5          5
-    //                                       beta                        ↑          ↑
-    //                                       edge                       13         13
-    //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
-    //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
-    //        0.3      -                     stable                      -          -
-    //                                       candidate                   -          -
-    //                                       beta                        -          -
-    //                                       edge                        -          -
-    // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
-    // `charmcraft status charmName --format json` returns these pointer releases with
-    // `release.status == tracking` and `release.revision == null`.
-    // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
-    // check candidate).
-    //
-    // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
-    // an error for this case.  This situation is identified by `release.status == closed`.
-    const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-    if (release.status === 'open') {
-        // Release exists.  Return it
-        return { i, release };
-    }
-    if (release.status === 'tracking') {
-        // Pointer to a safer channel.  Return that instead
-        const saferChannel = getSaferChannel(channel);
-        if (saferChannel === '') {
-            // no safer channel exists.  Should we throw?
-            throw new Error(`release.status == tracking for channel ${channel}, but no safer channel exists`);
-        }
-        return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
-    }
-    if (release.status === 'closed') {
-        // No release exists.  Throw
-        throw new Error(`No revision available in risk level ${channel}`);
-    }
-    throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
-}
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
@@ -21839,13 +21780,15 @@ class Charmcraft {
             if (channelIndex === -1) {
                 throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
             }
-            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === targetChannel);
+            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
             if (releaseIndex === -1) {
                 throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
             }
-            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(charmcraftStatus[trackIndex].channels[channelIndex].releases, targetChannel);
-            const { revision } = releaseObj;
-            const { resources } = releaseObj;
+            const releaseObj = charmcraftStatus[trackIndex].channels[channelIndex].releases[releaseIndex];
+            if (releaseObj.status !== 'open') {
+                throw new Error('Channel is not open. Make sure there was a release made to this channel previously.');
+            }
+            const { revision, resources } = releaseObj;
             const resourceInfoArray = [];
             for (let i = 0; i < resources.length; i += 1) {
                 resourceInfoArray.push({

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21773,18 +21773,18 @@ class Charmcraft {
             if (trackIndex === -1) {
                 throw new Error(`No track with name ${targetTrack}`);
             }
-            const channelIndex = charmcraftStatus[trackIndex].channels.findIndex((channel) => channel.base &&
+            const mappingIndex = charmcraftStatus[trackIndex].mappings.findIndex((channel) => channel.base &&
                 channel.base.name === targetBase.name &&
                 channel.base.channel === targetBase.channel &&
                 channel.base.architecture === targetBase.architecture);
-            if (channelIndex === -1) {
+            if (mappingIndex === -1) {
                 throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
             }
-            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
+            const releaseIndex = charmcraftStatus[trackIndex].mappings[mappingIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
             if (releaseIndex === -1) {
                 throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
             }
-            const releaseObj = charmcraftStatus[trackIndex].channels[channelIndex].releases[releaseIndex];
+            const releaseObj = charmcraftStatus[trackIndex].mappings[mappingIndex].releases[releaseIndex];
             if (releaseObj.status !== 'open') {
                 throw new Error('Channel is not open. Make sure there was a release made to this channel previously.');
             }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21764,7 +21764,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     }
     if (release.status === 'closed') {
         // No release exists.  Throw
-        throw new Error(`No revision available in channel ${channel}`);
+        throw new Error(`No revision available in risk level ${channel}`);
     }
     throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
 }
@@ -21997,9 +21997,19 @@ class Charmcraft {
             }
             // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
             const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
-            return { charmRev: revision, resources };
+            // console.log(`resources: ${JSON.stringify(resources)}`);
+            const resourceInfoArray = [];
+            for (let i = 0; i < resources.length; i += 1) {
+                // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
+                resourceInfoArray.push({
+                    resourceName: resources[i].name,
+                    resourceRev: resources[i].revision,
+                });
+            }
+            return { charmRev: revision, resources: resourceInfoArray };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21682,16 +21682,6 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
-function checkIfIsBase(baseRelease, base) {
-    const { name, channel: baseChannel, architecture } = base;
-    if (baseRelease.base === null) {
-        // This release has no base.  Nothing is here
-        return false;
-    }
-    return (baseRelease.base.name === name &&
-        baseRelease.base.channel === baseChannel &&
-        baseRelease.base.architecture === architecture);
-}
 function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
@@ -21701,23 +21691,6 @@ function getSaferChannel(channel) {
         return orderedChannels[iLessRisky];
     }
     return '';
-}
-function getTrackByName(trackArray, track) {
-    const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
-    if (i === -1) {
-        throw new Error(`No track with name ${track}`);
-    }
-    const trackObj = trackArray[i];
-    return { i, track: trackObj };
-}
-function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
-    // Accepts an array of {base: base_spec, releases: [releaseOnChannelA, releaseOnChannelB, ...]} objects,
-    // returning the releasOnChannelX releases array corresponding to the specified base
-    //
-    // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
-    const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
-    const releasesArray = baseReleaseArray[i].releases;
-    return { i, releases: releasesArray };
 }
 function getReleaseFromReleaseArrayByChannel(releases, channel) {
     const i = releases.findIndex((release) => release.channel === channel);
@@ -21982,24 +21955,30 @@ class Charmcraft {
             throw new Error(`No track with name ${track}`);
         });
     }
-    getRevisionInfoFromChannelJson(charm, track, channel, base) {
+    getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
             const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(channel)) {
-                throw new Error(`Provided channel ${channel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
+            if (!acceptedChannels.includes(targetChannel)) {
+                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
-            const { track: trackObj } = getTrackByName(charmcraftStatus, track);
-            // const trackObj = charmcraftStatus.filter((obj: any) => obj.track === track)
-            // const channelWithSpecifiedBase = trackObj.filter((releaseChannel: any) => releaseChannel.base.name === base.name && releaseChannel.base.channel === base.channel && releaseChannel.base.architecture === base.architecture)
-            // const targetRelease = channelWithSpecifiedBase.releases.filter((release: any) => release.channel === channel)
-            const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
-            if (releasesArray === null) {
-                throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
             }
-            // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
-            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            const channelIndex = charmcraftStatus[trackIndex].channels.findIndex((channel) => channel.base &&
+                channel.base.name === targetBase.name &&
+                channel.base.channel === targetBase.channel &&
+                channel.base.architecture === targetBase.architecture);
+            if (channelIndex === -1) {
+                throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
+            }
+            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === targetChannel);
+            if (releaseIndex === -1) {
+                throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
+            }
+            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(charmcraftStatus[trackIndex].channels[channelIndex].releases, targetChannel);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
             const resourceInfoArray = [];

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21696,22 +21696,18 @@ function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
     const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
     const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    // console.log(`found less risky channel is at index ${iLessRisky}`);
     if (iLessRisky >= 0) {
         return orderedChannels[iLessRisky];
     }
     return '';
 }
 function getTrackByName(trackArray, track) {
-    // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
     const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
     if (i === -1) {
         throw new Error(`No track with name ${track}`);
     }
     const trackObj = trackArray[i];
-    // console.log(`Found track ${track} at index ${i}: ${JSON.stringify(trackObj)}`);
     return { i, track: trackObj };
 }
 function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
@@ -21721,14 +21717,11 @@ function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
     // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
     const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
     const releasesArray = baseReleaseArray[i].releases;
-    // console.log(`Found releases ${base} at index ${i}: ${JSON.stringify(releasesArray)}`);
     return { i, releases: releasesArray };
 }
 function getReleaseFromReleaseArrayByChannel(releases, channel) {
-    // console.log(`releases: ${JSON.stringify(releases)}`)
     const i = releases.findIndex((release) => release.channel === channel);
     const releaseObj = releases[i];
-    // console.log(`Found release for channel ${channel} at index ${i}: ${JSON.stringify(releaseObj)}`);
     return { i, release: releaseObj };
 }
 function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
@@ -21755,9 +21748,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     //
     // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
     // an error for this case.  This situation is identified by `release.status == closed`.
-    // console.log(`releaseArray: ${JSON.stringify(releases)}`);
     const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-    // console.log(`release: ${JSON.stringify(release)}`);
     if (release.status === 'open') {
         // Release exists.  Return it
         return { i, release };
@@ -21999,27 +21990,26 @@ class Charmcraft {
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
-            // console.log(`charmcraftStatus: ${charmcraftStatus}`);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
+            // const trackObj = charmcraftStatus.filter((obj: any) => obj.track === track)
+            // const channelWithSpecifiedBase = trackObj.filter((releaseChannel: any) => releaseChannel.base.name === base.name && releaseChannel.base.channel === base.channel && releaseChannel.base.architecture === base.architecture)
+            // const targetRelease = channelWithSpecifiedBase.releases.filter((release: any) => release.channel === channel)
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {
                 throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
             }
             // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
             const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
-            // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
-            // console.log(`resources: ${JSON.stringify(resources)}`);
             const resourceInfoArray = [];
             for (let i = 0; i < resources.length; i += 1) {
-                // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
                 resourceInfoArray.push({
                     resourceName: resources[i].name,
-                    resourceRev: resources[i].revision,
+                    resourceRev: resources[i].revision.toString(),
                 });
             }
-            return { charmRev: revision, resources: resourceInfoArray };
+            return { charmRev: revision.toString(), resources: resourceInfoArray };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21982,7 +21982,7 @@ class Charmcraft {
             throw new Error(`No track with name ${track}`);
         });
     }
-    getRevisionInfoFromChannel_json(charm, track, channel) {
+    getRevisionInfoFromChannelJson(charm, track, channel, base) {
         return __awaiter(this, void 0, void 0, function* () {
             const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
             if (!acceptedChannels.includes(channel)) {
@@ -21991,8 +21991,6 @@ class Charmcraft {
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
-            // TODO: make base an input arg
-            const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {
                 throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21696,13 +21696,16 @@ function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
     const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+    // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
     const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    if (iLessRisky > 0) {
+    // console.log(`found less risky channel is at index ${iLessRisky}`);
+    if (iLessRisky >= 0) {
         return orderedChannels[iLessRisky];
     }
     return '';
 }
 function getTrackByName(trackArray, track) {
+    // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
     const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
     if (i === -1) {
         throw new Error(`No track with name ${track}`);
@@ -21752,7 +21755,9 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     //
     // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
     // an error for this case.  This situation is identified by `release.status == closed`.
+    // console.log(`releaseArray: ${JSON.stringify(releases)}`);
     const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
+    // console.log(`release: ${JSON.stringify(release)}`);
     if (release.status === 'open') {
         // Release exists.  Return it
         return { i, release };
@@ -21760,6 +21765,10 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     if (release.status === 'tracking') {
         // Pointer to a safer channel.  Return that instead
         const saferChannel = getSaferChannel(channel);
+        if (saferChannel === '') {
+            // no safer channel exists.  Should we throw?
+            throw new Error(`release.status == tracking for channel ${channel}, but no safer channel exists`);
+        }
         return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
     }
     if (release.status === 'closed') {
@@ -21990,6 +21999,7 @@ class Charmcraft {
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
+            // console.log(`charmcraftStatus: ${charmcraftStatus}`);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21908,18 +21908,18 @@ class Charmcraft {
             if (trackIndex === -1) {
                 throw new Error(`No track with name ${targetTrack}`);
             }
-            const channelIndex = charmcraftStatus[trackIndex].channels.findIndex((channel) => channel.base &&
+            const mappingIndex = charmcraftStatus[trackIndex].mappings.findIndex((channel) => channel.base &&
                 channel.base.name === targetBase.name &&
                 channel.base.channel === targetBase.channel &&
                 channel.base.architecture === targetBase.architecture);
-            if (channelIndex === -1) {
+            if (mappingIndex === -1) {
                 throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
             }
-            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
+            const releaseIndex = charmcraftStatus[trackIndex].mappings[mappingIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
             if (releaseIndex === -1) {
                 throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
             }
-            const releaseObj = charmcraftStatus[trackIndex].channels[channelIndex].releases[releaseIndex];
+            const releaseObj = charmcraftStatus[trackIndex].mappings[mappingIndex].releases[releaseIndex];
             if (releaseObj.status !== 'open') {
                 throw new Error('Channel is not open. Make sure there was a release made to this channel previously.');
             }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21682,65 +21682,6 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
-function getSaferChannel(channel) {
-    // Returns name of the next less risky channel, or an empty string if none exist
-    // standard channel names, from least to most risk
-    const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    if (iLessRisky >= 0) {
-        return orderedChannels[iLessRisky];
-    }
-    return '';
-}
-function getReleaseFromReleaseArrayByChannel(releases, channel) {
-    const i = releases.findIndex((release) => release.channel === channel);
-    const releaseObj = releases[i];
-    return { i, release: releaseObj };
-}
-function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
-    // Returns the release in an array of releases for a given channel, handling any null releases
-    //
-    // Some charmhub releases "point" to another release, for example:
-    //    `charmcraft status metacontroller-operator`:
-    //        Track    Base                  Channel                    Version    Revision    Expires at
-    //        latest   ubuntu 20.04 (amd64)  stable                      2          2
-    //                                       candidate                   5          5
-    //                                       beta                        ↑          ↑
-    //                                       edge                       13         13
-    //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
-    //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
-    //        0.3      -                     stable                      -          -
-    //                                       candidate                   -          -
-    //                                       beta                        -          -
-    //                                       edge                        -          -
-    // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
-    // `charmcraft status charmName --format json` returns these pointer releases with
-    // `release.status == tracking` and `release.revision == null`.
-    // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
-    // check candidate).
-    //
-    // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
-    // an error for this case.  This situation is identified by `release.status == closed`.
-    const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-    if (release.status === 'open') {
-        // Release exists.  Return it
-        return { i, release };
-    }
-    if (release.status === 'tracking') {
-        // Pointer to a safer channel.  Return that instead
-        const saferChannel = getSaferChannel(channel);
-        if (saferChannel === '') {
-            // no safer channel exists.  Should we throw?
-            throw new Error(`release.status == tracking for channel ${channel}, but no safer channel exists`);
-        }
-        return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
-    }
-    if (release.status === 'closed') {
-        // No release exists.  Throw
-        throw new Error(`No revision available in risk level ${channel}`);
-    }
-    throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
-}
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
@@ -21974,13 +21915,15 @@ class Charmcraft {
             if (channelIndex === -1) {
                 throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
             }
-            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === targetChannel);
+            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
             if (releaseIndex === -1) {
                 throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
             }
-            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(charmcraftStatus[trackIndex].channels[channelIndex].releases, targetChannel);
-            const { revision } = releaseObj;
-            const { resources } = releaseObj;
+            const releaseObj = charmcraftStatus[trackIndex].channels[channelIndex].releases[releaseIndex];
+            if (releaseObj.status !== 'open') {
+                throw new Error('Channel is not open. Make sure there was a release made to this channel previously.');
+            }
+            const { revision, resources } = releaseObj;
             const resourceInfoArray = [];
             for (let i = 0; i < resources.length; i += 1) {
                 resourceInfoArray.push({

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21682,6 +21682,92 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
+function checkIfIsBase(baseRelease, base) {
+    const { name, channel: baseChannel, architecture } = base;
+    if (baseRelease.base === null) {
+        // This release has no base.  Nothing is here
+        return false;
+    }
+    return (baseRelease.base.name === name &&
+        baseRelease.base.channel === baseChannel &&
+        baseRelease.base.architecture === architecture);
+}
+function getSaferChannel(channel) {
+    // Returns name of the next less risky channel, or an empty string if none exist
+    // standard channel names, from least to most risk
+    const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+    const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
+    if (iLessRisky > 0) {
+        return orderedChannels[iLessRisky];
+    }
+    return '';
+}
+function getTrackByName(trackArray, track) {
+    const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
+    if (i === -1) {
+        throw new Error(`No track with name ${track}`);
+    }
+    const trackObj = trackArray[i];
+    // console.log(`Found track ${track} at index ${i}: ${JSON.stringify(trackObj)}`);
+    return { i, track: trackObj };
+}
+function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
+    // Accepts an array of {base: base_spec, releases: [releaseOnChannelA, releaseOnChannelB, ...]} objects,
+    // returning the releasOnChannelX releases array corresponding to the specified base
+    //
+    // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
+    const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
+    const releasesArray = baseReleaseArray[i].releases;
+    // console.log(`Found releases ${base} at index ${i}: ${JSON.stringify(releasesArray)}`);
+    return { i, releases: releasesArray };
+}
+function getReleaseFromReleaseArrayByChannel(releases, channel) {
+    // console.log(`releases: ${JSON.stringify(releases)}`)
+    const i = releases.findIndex((release) => release.channel === channel);
+    const releaseObj = releases[i];
+    // console.log(`Found release for channel ${channel} at index ${i}: ${JSON.stringify(releaseObj)}`);
+    return { i, release: releaseObj };
+}
+function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
+    // Returns the release in an array of releases for a given channel, handling any null releases
+    //
+    // Some charmhub releases "point" to another release, for example:
+    //    `charmcraft status metacontroller-operator`:
+    //        Track    Base                  Channel                    Version    Revision    Expires at
+    //        latest   ubuntu 20.04 (amd64)  stable                      2          2
+    //                                       candidate                   5          5
+    //                                       beta                        ↑          ↑
+    //                                       edge                       13         13
+    //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
+    //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
+    //        0.3      -                     stable                      -          -
+    //                                       candidate                   -          -
+    //                                       beta                        -          -
+    //                                       edge                        -          -
+    // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
+    // `charmcraft status charmName --format json` returns these pointer releases with
+    // `release.status == tracking` and `release.revision == null`.
+    // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
+    // check candidate).
+    //
+    // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
+    // an error for this case.  This situation is identified by `release.status == closed`.
+    const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
+    if (release.status === 'open') {
+        // Release exists.  Return it
+        return { i, release };
+    }
+    if (release.status === 'tracking') {
+        // Pointer to a safer channel.  Return that instead
+        const saferChannel = getSaferChannel(channel);
+        return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
+    }
+    if (release.status === 'closed') {
+        // No release exists.  Throw
+        throw new Error(`No revision available in channel ${channel}`);
+    }
+    throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
+}
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
@@ -21845,6 +21931,13 @@ class Charmcraft {
             return result.stdout;
         });
     }
+    statusJson(charm) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const parsedObj = JSON.parse(result.stdout);
+            return parsedObj;
+        });
+    }
     getRevisionInfoFromChannel(charm, track, channel) {
         return __awaiter(this, void 0, void 0, function* () {
             // For now we have to parse the `charmcraft status` output this will soon be fixed
@@ -21887,6 +21980,28 @@ class Charmcraft {
                 }
             }
             throw new Error(`No track with name ${track}`);
+        });
+    }
+    getRevisionInfoFromChannel_json(charm, track, channel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
+            if (!acceptedChannels.includes(channel)) {
+                throw new Error(`Provided channel ${channel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
+            }
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const { track: trackObj } = getTrackByName(charmcraftStatus, track);
+            // TODO: make base an input arg
+            const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
+            const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
+            if (releasesArray === null) {
+                throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
+            }
+            // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
+            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            const { revision } = releaseObj;
+            const { resources } = releaseObj;
+            return { charmRev: revision, resources };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21630,6 +21630,92 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
+function checkIfIsBase(baseRelease, base) {
+    const { name, channel: baseChannel, architecture } = base;
+    if (baseRelease.base === null) {
+        // This release has no base.  Nothing is here
+        return false;
+    }
+    return (baseRelease.base.name === name &&
+        baseRelease.base.channel === baseChannel &&
+        baseRelease.base.architecture === architecture);
+}
+function getSaferChannel(channel) {
+    // Returns name of the next less risky channel, or an empty string if none exist
+    // standard channel names, from least to most risk
+    const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+    const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
+    if (iLessRisky > 0) {
+        return orderedChannels[iLessRisky];
+    }
+    return '';
+}
+function getTrackByName(trackArray, track) {
+    const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
+    if (i === -1) {
+        throw new Error(`No track with name ${track}`);
+    }
+    const trackObj = trackArray[i];
+    // console.log(`Found track ${track} at index ${i}: ${JSON.stringify(trackObj)}`);
+    return { i, track: trackObj };
+}
+function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
+    // Accepts an array of {base: base_spec, releases: [releaseOnChannelA, releaseOnChannelB, ...]} objects,
+    // returning the releasOnChannelX releases array corresponding to the specified base
+    //
+    // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
+    const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
+    const releasesArray = baseReleaseArray[i].releases;
+    // console.log(`Found releases ${base} at index ${i}: ${JSON.stringify(releasesArray)}`);
+    return { i, releases: releasesArray };
+}
+function getReleaseFromReleaseArrayByChannel(releases, channel) {
+    // console.log(`releases: ${JSON.stringify(releases)}`)
+    const i = releases.findIndex((release) => release.channel === channel);
+    const releaseObj = releases[i];
+    // console.log(`Found release for channel ${channel} at index ${i}: ${JSON.stringify(releaseObj)}`);
+    return { i, release: releaseObj };
+}
+function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
+    // Returns the release in an array of releases for a given channel, handling any null releases
+    //
+    // Some charmhub releases "point" to another release, for example:
+    //    `charmcraft status metacontroller-operator`:
+    //        Track    Base                  Channel                    Version    Revision    Expires at
+    //        latest   ubuntu 20.04 (amd64)  stable                      2          2
+    //                                       candidate                   5          5
+    //                                       beta                        ↑          ↑
+    //                                       edge                       13         13
+    //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
+    //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
+    //        0.3      -                     stable                      -          -
+    //                                       candidate                   -          -
+    //                                       beta                        -          -
+    //                                       edge                        -          -
+    // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
+    // `charmcraft status charmName --format json` returns these pointer releases with
+    // `release.status == tracking` and `release.revision == null`.
+    // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
+    // check candidate).
+    //
+    // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
+    // an error for this case.  This situation is identified by `release.status == closed`.
+    const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
+    if (release.status === 'open') {
+        // Release exists.  Return it
+        return { i, release };
+    }
+    if (release.status === 'tracking') {
+        // Pointer to a safer channel.  Return that instead
+        const saferChannel = getSaferChannel(channel);
+        return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
+    }
+    if (release.status === 'closed') {
+        // No release exists.  Throw
+        throw new Error(`No revision available in channel ${channel}`);
+    }
+    throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
+}
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
@@ -21793,6 +21879,13 @@ class Charmcraft {
             return result.stdout;
         });
     }
+    statusJson(charm) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const parsedObj = JSON.parse(result.stdout);
+            return parsedObj;
+        });
+    }
     getRevisionInfoFromChannel(charm, track, channel) {
         return __awaiter(this, void 0, void 0, function* () {
             // For now we have to parse the `charmcraft status` output this will soon be fixed
@@ -21835,6 +21928,28 @@ class Charmcraft {
                 }
             }
             throw new Error(`No track with name ${track}`);
+        });
+    }
+    getRevisionInfoFromChannel_json(charm, track, channel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
+            if (!acceptedChannels.includes(channel)) {
+                throw new Error(`Provided channel ${channel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
+            }
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const { track: trackObj } = getTrackByName(charmcraftStatus, track);
+            // TODO: make base an input arg
+            const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
+            const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
+            if (releasesArray === null) {
+                throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
+            }
+            // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
+            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            const { revision } = releaseObj;
+            const { resources } = releaseObj;
+            return { charmRev: revision, resources };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21714,7 +21714,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     }
     if (release.status === 'closed') {
         // No release exists.  Throw
-        throw new Error(`No revision available in channel ${channel}`);
+        throw new Error(`No revision available in risk level ${channel}`);
     }
     throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
 }
@@ -21947,9 +21947,19 @@ class Charmcraft {
             }
             // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
             const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
-            return { charmRev: revision, resources };
+            // console.log(`resources: ${JSON.stringify(resources)}`);
+            const resourceInfoArray = [];
+            for (let i = 0; i < resources.length; i += 1) {
+                // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
+                resourceInfoArray.push({
+                    resourceName: resources[i].name,
+                    resourceRev: resources[i].revision,
+                });
+            }
+            return { charmRev: revision, resources: resourceInfoArray };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21646,13 +21646,16 @@ function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
     const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+    // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
     const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    if (iLessRisky > 0) {
+    // console.log(`found less risky channel is at index ${iLessRisky}`);
+    if (iLessRisky >= 0) {
         return orderedChannels[iLessRisky];
     }
     return '';
 }
 function getTrackByName(trackArray, track) {
+    // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
     const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
     if (i === -1) {
         throw new Error(`No track with name ${track}`);
@@ -21702,7 +21705,9 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     //
     // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
     // an error for this case.  This situation is identified by `release.status == closed`.
+    // console.log(`releaseArray: ${JSON.stringify(releases)}`);
     const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
+    // console.log(`release: ${JSON.stringify(release)}`);
     if (release.status === 'open') {
         // Release exists.  Return it
         return { i, release };
@@ -21710,6 +21715,10 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     if (release.status === 'tracking') {
         // Pointer to a safer channel.  Return that instead
         const saferChannel = getSaferChannel(channel);
+        if (saferChannel === '') {
+            // no safer channel exists.  Should we throw?
+            throw new Error(`release.status == tracking for channel ${channel}, but no safer channel exists`);
+        }
         return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
     }
     if (release.status === 'closed') {
@@ -21940,6 +21949,7 @@ class Charmcraft {
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
+            // console.log(`charmcraftStatus: ${charmcraftStatus}`);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21864,18 +21864,18 @@ class Charmcraft {
             if (trackIndex === -1) {
                 throw new Error(`No track with name ${targetTrack}`);
             }
-            const channelIndex = charmcraftStatus[trackIndex].channels.findIndex((channel) => channel.base &&
+            const mappingIndex = charmcraftStatus[trackIndex].mappings.findIndex((channel) => channel.base &&
                 channel.base.name === targetBase.name &&
                 channel.base.channel === targetBase.channel &&
                 channel.base.architecture === targetBase.architecture);
-            if (channelIndex === -1) {
+            if (mappingIndex === -1) {
                 throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
             }
-            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
+            const releaseIndex = charmcraftStatus[trackIndex].mappings[mappingIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
             if (releaseIndex === -1) {
                 throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
             }
-            const releaseObj = charmcraftStatus[trackIndex].channels[channelIndex].releases[releaseIndex];
+            const releaseObj = charmcraftStatus[trackIndex].mappings[mappingIndex].releases[releaseIndex];
             if (releaseObj.status !== 'open') {
                 throw new Error('Channel is not open. Make sure there was a release made to this channel previously.');
             }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21646,22 +21646,18 @@ function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
     const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
     const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    // console.log(`found less risky channel is at index ${iLessRisky}`);
     if (iLessRisky >= 0) {
         return orderedChannels[iLessRisky];
     }
     return '';
 }
 function getTrackByName(trackArray, track) {
-    // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
     const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
     if (i === -1) {
         throw new Error(`No track with name ${track}`);
     }
     const trackObj = trackArray[i];
-    // console.log(`Found track ${track} at index ${i}: ${JSON.stringify(trackObj)}`);
     return { i, track: trackObj };
 }
 function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
@@ -21671,14 +21667,11 @@ function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
     // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
     const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
     const releasesArray = baseReleaseArray[i].releases;
-    // console.log(`Found releases ${base} at index ${i}: ${JSON.stringify(releasesArray)}`);
     return { i, releases: releasesArray };
 }
 function getReleaseFromReleaseArrayByChannel(releases, channel) {
-    // console.log(`releases: ${JSON.stringify(releases)}`)
     const i = releases.findIndex((release) => release.channel === channel);
     const releaseObj = releases[i];
-    // console.log(`Found release for channel ${channel} at index ${i}: ${JSON.stringify(releaseObj)}`);
     return { i, release: releaseObj };
 }
 function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
@@ -21705,9 +21698,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     //
     // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
     // an error for this case.  This situation is identified by `release.status == closed`.
-    // console.log(`releaseArray: ${JSON.stringify(releases)}`);
     const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-    // console.log(`release: ${JSON.stringify(release)}`);
     if (release.status === 'open') {
         // Release exists.  Return it
         return { i, release };
@@ -21949,27 +21940,26 @@ class Charmcraft {
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
-            // console.log(`charmcraftStatus: ${charmcraftStatus}`);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
+            // const trackObj = charmcraftStatus.filter((obj: any) => obj.track === track)
+            // const channelWithSpecifiedBase = trackObj.filter((releaseChannel: any) => releaseChannel.base.name === base.name && releaseChannel.base.channel === base.channel && releaseChannel.base.architecture === base.architecture)
+            // const targetRelease = channelWithSpecifiedBase.releases.filter((release: any) => release.channel === channel)
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {
                 throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
             }
             // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
             const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
-            // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
-            // console.log(`resources: ${JSON.stringify(resources)}`);
             const resourceInfoArray = [];
             for (let i = 0; i < resources.length; i += 1) {
-                // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
                 resourceInfoArray.push({
                     resourceName: resources[i].name,
-                    resourceRev: resources[i].revision,
+                    resourceRev: resources[i].revision.toString(),
                 });
             }
-            return { charmRev: revision, resources: resourceInfoArray };
+            return { charmRev: revision.toString(), resources: resourceInfoArray };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21388,7 +21388,6 @@ class ReleaseCharmAction {
                 process.chdir(this.charmPath);
                 const { name: charmName } = this.charmcraft.metadata();
                 const [originTrack, originChannel] = this.originChannel.split('/');
-                // TODO: Handle base more robustly
                 const base = {
                     name: this.baseName,
                     channel: this.baseChannel,

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21638,65 +21638,6 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
-function getSaferChannel(channel) {
-    // Returns name of the next less risky channel, or an empty string if none exist
-    // standard channel names, from least to most risk
-    const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    if (iLessRisky >= 0) {
-        return orderedChannels[iLessRisky];
-    }
-    return '';
-}
-function getReleaseFromReleaseArrayByChannel(releases, channel) {
-    const i = releases.findIndex((release) => release.channel === channel);
-    const releaseObj = releases[i];
-    return { i, release: releaseObj };
-}
-function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
-    // Returns the release in an array of releases for a given channel, handling any null releases
-    //
-    // Some charmhub releases "point" to another release, for example:
-    //    `charmcraft status metacontroller-operator`:
-    //        Track    Base                  Channel                    Version    Revision    Expires at
-    //        latest   ubuntu 20.04 (amd64)  stable                      2          2
-    //                                       candidate                   5          5
-    //                                       beta                        ↑          ↑
-    //                                       edge                       13         13
-    //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
-    //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
-    //        0.3      -                     stable                      -          -
-    //                                       candidate                   -          -
-    //                                       beta                        -          -
-    //                                       edge                        -          -
-    // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
-    // `charmcraft status charmName --format json` returns these pointer releases with
-    // `release.status == tracking` and `release.revision == null`.
-    // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
-    // check candidate).
-    //
-    // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
-    // an error for this case.  This situation is identified by `release.status == closed`.
-    const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-    if (release.status === 'open') {
-        // Release exists.  Return it
-        return { i, release };
-    }
-    if (release.status === 'tracking') {
-        // Pointer to a safer channel.  Return that instead
-        const saferChannel = getSaferChannel(channel);
-        if (saferChannel === '') {
-            // no safer channel exists.  Should we throw?
-            throw new Error(`release.status == tracking for channel ${channel}, but no safer channel exists`);
-        }
-        return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
-    }
-    if (release.status === 'closed') {
-        // No release exists.  Throw
-        throw new Error(`No revision available in risk level ${channel}`);
-    }
-    throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
-}
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
@@ -21930,13 +21871,15 @@ class Charmcraft {
             if (channelIndex === -1) {
                 throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
             }
-            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === targetChannel);
+            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
             if (releaseIndex === -1) {
                 throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
             }
-            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(charmcraftStatus[trackIndex].channels[channelIndex].releases, targetChannel);
-            const { revision } = releaseObj;
-            const { resources } = releaseObj;
+            const releaseObj = charmcraftStatus[trackIndex].channels[channelIndex].releases[releaseIndex];
+            if (releaseObj.status !== 'open') {
+                throw new Error('Channel is not open. Make sure there was a release made to this channel previously.');
+            }
+            const { revision, resources } = releaseObj;
             const resourceInfoArray = [];
             for (let i = 0; i < resources.length; i += 1) {
                 resourceInfoArray.push({

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21617,6 +21617,92 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
+function checkIfIsBase(baseRelease, base) {
+    const { name, channel: baseChannel, architecture } = base;
+    if (baseRelease.base === null) {
+        // This release has no base.  Nothing is here
+        return false;
+    }
+    return (baseRelease.base.name === name &&
+        baseRelease.base.channel === baseChannel &&
+        baseRelease.base.architecture === architecture);
+}
+function getSaferChannel(channel) {
+    // Returns name of the next less risky channel, or an empty string if none exist
+    // standard channel names, from least to most risk
+    const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+    const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
+    if (iLessRisky > 0) {
+        return orderedChannels[iLessRisky];
+    }
+    return '';
+}
+function getTrackByName(trackArray, track) {
+    const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
+    if (i === -1) {
+        throw new Error(`No track with name ${track}`);
+    }
+    const trackObj = trackArray[i];
+    // console.log(`Found track ${track} at index ${i}: ${JSON.stringify(trackObj)}`);
+    return { i, track: trackObj };
+}
+function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
+    // Accepts an array of {base: base_spec, releases: [releaseOnChannelA, releaseOnChannelB, ...]} objects,
+    // returning the releasOnChannelX releases array corresponding to the specified base
+    //
+    // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
+    const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
+    const releasesArray = baseReleaseArray[i].releases;
+    // console.log(`Found releases ${base} at index ${i}: ${JSON.stringify(releasesArray)}`);
+    return { i, releases: releasesArray };
+}
+function getReleaseFromReleaseArrayByChannel(releases, channel) {
+    // console.log(`releases: ${JSON.stringify(releases)}`)
+    const i = releases.findIndex((release) => release.channel === channel);
+    const releaseObj = releases[i];
+    // console.log(`Found release for channel ${channel} at index ${i}: ${JSON.stringify(releaseObj)}`);
+    return { i, release: releaseObj };
+}
+function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
+    // Returns the release in an array of releases for a given channel, handling any null releases
+    //
+    // Some charmhub releases "point" to another release, for example:
+    //    `charmcraft status metacontroller-operator`:
+    //        Track    Base                  Channel                    Version    Revision    Expires at
+    //        latest   ubuntu 20.04 (amd64)  stable                      2          2
+    //                                       candidate                   5          5
+    //                                       beta                        ↑          ↑
+    //                                       edge                       13         13
+    //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
+    //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
+    //        0.3      -                     stable                      -          -
+    //                                       candidate                   -          -
+    //                                       beta                        -          -
+    //                                       edge                        -          -
+    // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
+    // `charmcraft status charmName --format json` returns these pointer releases with
+    // `release.status == tracking` and `release.revision == null`.
+    // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
+    // check candidate).
+    //
+    // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
+    // an error for this case.  This situation is identified by `release.status == closed`.
+    const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
+    if (release.status === 'open') {
+        // Release exists.  Return it
+        return { i, release };
+    }
+    if (release.status === 'tracking') {
+        // Pointer to a safer channel.  Return that instead
+        const saferChannel = getSaferChannel(channel);
+        return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
+    }
+    if (release.status === 'closed') {
+        // No release exists.  Throw
+        throw new Error(`No revision available in channel ${channel}`);
+    }
+    throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
+}
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
@@ -21780,6 +21866,13 @@ class Charmcraft {
             return result.stdout;
         });
     }
+    statusJson(charm) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const parsedObj = JSON.parse(result.stdout);
+            return parsedObj;
+        });
+    }
     getRevisionInfoFromChannel(charm, track, channel) {
         return __awaiter(this, void 0, void 0, function* () {
             // For now we have to parse the `charmcraft status` output this will soon be fixed
@@ -21822,6 +21915,28 @@ class Charmcraft {
                 }
             }
             throw new Error(`No track with name ${track}`);
+        });
+    }
+    getRevisionInfoFromChannel_json(charm, track, channel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
+            if (!acceptedChannels.includes(channel)) {
+                throw new Error(`Provided channel ${channel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
+            }
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const { track: trackObj } = getTrackByName(charmcraftStatus, track);
+            // TODO: make base an input arg
+            const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
+            const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
+            if (releasesArray === null) {
+                throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
+            }
+            // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
+            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            const { revision } = releaseObj;
+            const { resources } = releaseObj;
+            return { charmRev: revision, resources };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21917,7 +21917,7 @@ class Charmcraft {
             throw new Error(`No track with name ${track}`);
         });
     }
-    getRevisionInfoFromChannel_json(charm, track, channel) {
+    getRevisionInfoFromChannelJson(charm, track, channel, base) {
         return __awaiter(this, void 0, void 0, function* () {
             const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
             if (!acceptedChannels.includes(channel)) {
@@ -21926,8 +21926,6 @@ class Charmcraft {
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
-            // TODO: make base an input arg
-            const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {
                 throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21631,13 +21631,16 @@ function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
     const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+    // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
     const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    if (iLessRisky > 0) {
+    // console.log(`found less risky channel is at index ${iLessRisky}`);
+    if (iLessRisky >= 0) {
         return orderedChannels[iLessRisky];
     }
     return '';
 }
 function getTrackByName(trackArray, track) {
+    // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
     const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
     if (i === -1) {
         throw new Error(`No track with name ${track}`);
@@ -21687,7 +21690,9 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     //
     // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
     // an error for this case.  This situation is identified by `release.status == closed`.
+    // console.log(`releaseArray: ${JSON.stringify(releases)}`);
     const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
+    // console.log(`release: ${JSON.stringify(release)}`);
     if (release.status === 'open') {
         // Release exists.  Return it
         return { i, release };
@@ -21695,6 +21700,10 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     if (release.status === 'tracking') {
         // Pointer to a safer channel.  Return that instead
         const saferChannel = getSaferChannel(channel);
+        if (saferChannel === '') {
+            // no safer channel exists.  Should we throw?
+            throw new Error(`release.status == tracking for channel ${channel}, but no safer channel exists`);
+        }
         return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
     }
     if (release.status === 'closed') {
@@ -21925,6 +21934,7 @@ class Charmcraft {
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
+            // console.log(`charmcraftStatus: ${charmcraftStatus}`);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21617,65 +21617,6 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
-function getSaferChannel(channel) {
-    // Returns name of the next less risky channel, or an empty string if none exist
-    // standard channel names, from least to most risk
-    const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    if (iLessRisky >= 0) {
-        return orderedChannels[iLessRisky];
-    }
-    return '';
-}
-function getReleaseFromReleaseArrayByChannel(releases, channel) {
-    const i = releases.findIndex((release) => release.channel === channel);
-    const releaseObj = releases[i];
-    return { i, release: releaseObj };
-}
-function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
-    // Returns the release in an array of releases for a given channel, handling any null releases
-    //
-    // Some charmhub releases "point" to another release, for example:
-    //    `charmcraft status metacontroller-operator`:
-    //        Track    Base                  Channel                    Version    Revision    Expires at
-    //        latest   ubuntu 20.04 (amd64)  stable                      2          2
-    //                                       candidate                   5          5
-    //                                       beta                        ↑          ↑
-    //                                       edge                       13         13
-    //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
-    //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
-    //        0.3      -                     stable                      -          -
-    //                                       candidate                   -          -
-    //                                       beta                        -          -
-    //                                       edge                        -          -
-    // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
-    // `charmcraft status charmName --format json` returns these pointer releases with
-    // `release.status == tracking` and `release.revision == null`.
-    // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
-    // check candidate).
-    //
-    // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
-    // an error for this case.  This situation is identified by `release.status == closed`.
-    const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-    if (release.status === 'open') {
-        // Release exists.  Return it
-        return { i, release };
-    }
-    if (release.status === 'tracking') {
-        // Pointer to a safer channel.  Return that instead
-        const saferChannel = getSaferChannel(channel);
-        if (saferChannel === '') {
-            // no safer channel exists.  Should we throw?
-            throw new Error(`release.status == tracking for channel ${channel}, but no safer channel exists`);
-        }
-        return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
-    }
-    if (release.status === 'closed') {
-        // No release exists.  Throw
-        throw new Error(`No revision available in risk level ${channel}`);
-    }
-    throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
-}
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
@@ -21909,13 +21850,15 @@ class Charmcraft {
             if (channelIndex === -1) {
                 throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
             }
-            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === targetChannel);
+            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
             if (releaseIndex === -1) {
                 throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
             }
-            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(charmcraftStatus[trackIndex].channels[channelIndex].releases, targetChannel);
-            const { revision } = releaseObj;
-            const { resources } = releaseObj;
+            const releaseObj = charmcraftStatus[trackIndex].channels[channelIndex].releases[releaseIndex];
+            if (releaseObj.status !== 'open') {
+                throw new Error('Channel is not open. Make sure there was a release made to this channel previously.');
+            }
+            const { revision, resources } = releaseObj;
             const resourceInfoArray = [];
             for (let i = 0; i < resources.length; i += 1) {
                 resourceInfoArray.push({

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21631,22 +21631,18 @@ function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
     const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
     const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    // console.log(`found less risky channel is at index ${iLessRisky}`);
     if (iLessRisky >= 0) {
         return orderedChannels[iLessRisky];
     }
     return '';
 }
 function getTrackByName(trackArray, track) {
-    // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
     const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
     if (i === -1) {
         throw new Error(`No track with name ${track}`);
     }
     const trackObj = trackArray[i];
-    // console.log(`Found track ${track} at index ${i}: ${JSON.stringify(trackObj)}`);
     return { i, track: trackObj };
 }
 function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
@@ -21656,14 +21652,11 @@ function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
     // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
     const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
     const releasesArray = baseReleaseArray[i].releases;
-    // console.log(`Found releases ${base} at index ${i}: ${JSON.stringify(releasesArray)}`);
     return { i, releases: releasesArray };
 }
 function getReleaseFromReleaseArrayByChannel(releases, channel) {
-    // console.log(`releases: ${JSON.stringify(releases)}`)
     const i = releases.findIndex((release) => release.channel === channel);
     const releaseObj = releases[i];
-    // console.log(`Found release for channel ${channel} at index ${i}: ${JSON.stringify(releaseObj)}`);
     return { i, release: releaseObj };
 }
 function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
@@ -21690,9 +21683,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     //
     // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
     // an error for this case.  This situation is identified by `release.status == closed`.
-    // console.log(`releaseArray: ${JSON.stringify(releases)}`);
     const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-    // console.log(`release: ${JSON.stringify(release)}`);
     if (release.status === 'open') {
         // Release exists.  Return it
         return { i, release };
@@ -21934,27 +21925,26 @@ class Charmcraft {
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
-            // console.log(`charmcraftStatus: ${charmcraftStatus}`);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
+            // const trackObj = charmcraftStatus.filter((obj: any) => obj.track === track)
+            // const channelWithSpecifiedBase = trackObj.filter((releaseChannel: any) => releaseChannel.base.name === base.name && releaseChannel.base.channel === base.channel && releaseChannel.base.architecture === base.architecture)
+            // const targetRelease = channelWithSpecifiedBase.releases.filter((release: any) => release.channel === channel)
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {
                 throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
             }
             // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
             const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
-            // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
-            // console.log(`resources: ${JSON.stringify(resources)}`);
             const resourceInfoArray = [];
             for (let i = 0; i < resources.length; i += 1) {
-                // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
                 resourceInfoArray.push({
                     resourceName: resources[i].name,
-                    resourceRev: resources[i].revision,
+                    resourceRev: resources[i].revision.toString(),
                 });
             }
-            return { charmRev: revision, resources: resourceInfoArray };
+            return { charmRev: revision.toString(), resources: resourceInfoArray };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21617,16 +21617,6 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
-function checkIfIsBase(baseRelease, base) {
-    const { name, channel: baseChannel, architecture } = base;
-    if (baseRelease.base === null) {
-        // This release has no base.  Nothing is here
-        return false;
-    }
-    return (baseRelease.base.name === name &&
-        baseRelease.base.channel === baseChannel &&
-        baseRelease.base.architecture === architecture);
-}
 function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
@@ -21636,23 +21626,6 @@ function getSaferChannel(channel) {
         return orderedChannels[iLessRisky];
     }
     return '';
-}
-function getTrackByName(trackArray, track) {
-    const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
-    if (i === -1) {
-        throw new Error(`No track with name ${track}`);
-    }
-    const trackObj = trackArray[i];
-    return { i, track: trackObj };
-}
-function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
-    // Accepts an array of {base: base_spec, releases: [releaseOnChannelA, releaseOnChannelB, ...]} objects,
-    // returning the releasOnChannelX releases array corresponding to the specified base
-    //
-    // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
-    const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
-    const releasesArray = baseReleaseArray[i].releases;
-    return { i, releases: releasesArray };
 }
 function getReleaseFromReleaseArrayByChannel(releases, channel) {
     const i = releases.findIndex((release) => release.channel === channel);
@@ -21917,24 +21890,30 @@ class Charmcraft {
             throw new Error(`No track with name ${track}`);
         });
     }
-    getRevisionInfoFromChannelJson(charm, track, channel, base) {
+    getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
             const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(channel)) {
-                throw new Error(`Provided channel ${channel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
+            if (!acceptedChannels.includes(targetChannel)) {
+                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
-            const { track: trackObj } = getTrackByName(charmcraftStatus, track);
-            // const trackObj = charmcraftStatus.filter((obj: any) => obj.track === track)
-            // const channelWithSpecifiedBase = trackObj.filter((releaseChannel: any) => releaseChannel.base.name === base.name && releaseChannel.base.channel === base.channel && releaseChannel.base.architecture === base.architecture)
-            // const targetRelease = channelWithSpecifiedBase.releases.filter((release: any) => release.channel === channel)
-            const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
-            if (releasesArray === null) {
-                throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
             }
-            // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
-            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            const channelIndex = charmcraftStatus[trackIndex].channels.findIndex((channel) => channel.base &&
+                channel.base.name === targetBase.name &&
+                channel.base.channel === targetBase.channel &&
+                channel.base.architecture === targetBase.architecture);
+            if (channelIndex === -1) {
+                throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
+            }
+            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === targetChannel);
+            if (releaseIndex === -1) {
+                throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
+            }
+            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(charmcraftStatus[trackIndex].channels[channelIndex].releases, targetChannel);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
             const resourceInfoArray = [];

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21699,7 +21699,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     }
     if (release.status === 'closed') {
         // No release exists.  Throw
-        throw new Error(`No revision available in channel ${channel}`);
+        throw new Error(`No revision available in risk level ${channel}`);
     }
     throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
 }
@@ -21932,9 +21932,19 @@ class Charmcraft {
             }
             // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
             const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
-            return { charmRev: revision, resources };
+            // console.log(`resources: ${JSON.stringify(resources)}`);
+            const resourceInfoArray = [];
+            for (let i = 0; i < resources.length; i += 1) {
+                // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
+                resourceInfoArray.push({
+                    resourceName: resources[i].name,
+                    resourceRev: resources[i].revision,
+                });
+            }
+            return { charmRev: revision, resources: resourceInfoArray };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21843,18 +21843,18 @@ class Charmcraft {
             if (trackIndex === -1) {
                 throw new Error(`No track with name ${targetTrack}`);
             }
-            const channelIndex = charmcraftStatus[trackIndex].channels.findIndex((channel) => channel.base &&
+            const mappingIndex = charmcraftStatus[trackIndex].mappings.findIndex((channel) => channel.base &&
                 channel.base.name === targetBase.name &&
                 channel.base.channel === targetBase.channel &&
                 channel.base.architecture === targetBase.architecture);
-            if (channelIndex === -1) {
+            if (mappingIndex === -1) {
                 throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
             }
-            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
+            const releaseIndex = charmcraftStatus[trackIndex].mappings[mappingIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
             if (releaseIndex === -1) {
                 throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
             }
-            const releaseObj = charmcraftStatus[trackIndex].channels[channelIndex].releases[releaseIndex];
+            const releaseObj = charmcraftStatus[trackIndex].mappings[mappingIndex].releases[releaseIndex];
             if (releaseObj.status !== 'open') {
                 throw new Error('Channel is not open. Make sure there was a release made to this channel previously.');
             }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21658,22 +21658,18 @@ function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
     const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
     const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    // console.log(`found less risky channel is at index ${iLessRisky}`);
     if (iLessRisky >= 0) {
         return orderedChannels[iLessRisky];
     }
     return '';
 }
 function getTrackByName(trackArray, track) {
-    // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
     const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
     if (i === -1) {
         throw new Error(`No track with name ${track}`);
     }
     const trackObj = trackArray[i];
-    // console.log(`Found track ${track} at index ${i}: ${JSON.stringify(trackObj)}`);
     return { i, track: trackObj };
 }
 function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
@@ -21683,14 +21679,11 @@ function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
     // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
     const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
     const releasesArray = baseReleaseArray[i].releases;
-    // console.log(`Found releases ${base} at index ${i}: ${JSON.stringify(releasesArray)}`);
     return { i, releases: releasesArray };
 }
 function getReleaseFromReleaseArrayByChannel(releases, channel) {
-    // console.log(`releases: ${JSON.stringify(releases)}`)
     const i = releases.findIndex((release) => release.channel === channel);
     const releaseObj = releases[i];
-    // console.log(`Found release for channel ${channel} at index ${i}: ${JSON.stringify(releaseObj)}`);
     return { i, release: releaseObj };
 }
 function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
@@ -21717,9 +21710,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     //
     // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
     // an error for this case.  This situation is identified by `release.status == closed`.
-    // console.log(`releaseArray: ${JSON.stringify(releases)}`);
     const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-    // console.log(`release: ${JSON.stringify(release)}`);
     if (release.status === 'open') {
         // Release exists.  Return it
         return { i, release };
@@ -21961,27 +21952,26 @@ class Charmcraft {
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
-            // console.log(`charmcraftStatus: ${charmcraftStatus}`);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
+            // const trackObj = charmcraftStatus.filter((obj: any) => obj.track === track)
+            // const channelWithSpecifiedBase = trackObj.filter((releaseChannel: any) => releaseChannel.base.name === base.name && releaseChannel.base.channel === base.channel && releaseChannel.base.architecture === base.architecture)
+            // const targetRelease = channelWithSpecifiedBase.releases.filter((release: any) => release.channel === channel)
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {
                 throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
             }
             // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
             const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
-            // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
-            // console.log(`resources: ${JSON.stringify(resources)}`);
             const resourceInfoArray = [];
             for (let i = 0; i < resources.length; i += 1) {
-                // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
                 resourceInfoArray.push({
                     resourceName: resources[i].name,
-                    resourceRev: resources[i].revision,
+                    resourceRev: resources[i].revision.toString(),
                 });
             }
-            return { charmRev: revision, resources: resourceInfoArray };
+            return { charmRev: revision.toString(), resources: resourceInfoArray };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21644,6 +21644,92 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
+function checkIfIsBase(baseRelease, base) {
+    const { name, channel: baseChannel, architecture } = base;
+    if (baseRelease.base === null) {
+        // This release has no base.  Nothing is here
+        return false;
+    }
+    return (baseRelease.base.name === name &&
+        baseRelease.base.channel === baseChannel &&
+        baseRelease.base.architecture === architecture);
+}
+function getSaferChannel(channel) {
+    // Returns name of the next less risky channel, or an empty string if none exist
+    // standard channel names, from least to most risk
+    const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+    const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
+    if (iLessRisky > 0) {
+        return orderedChannels[iLessRisky];
+    }
+    return '';
+}
+function getTrackByName(trackArray, track) {
+    const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
+    if (i === -1) {
+        throw new Error(`No track with name ${track}`);
+    }
+    const trackObj = trackArray[i];
+    // console.log(`Found track ${track} at index ${i}: ${JSON.stringify(trackObj)}`);
+    return { i, track: trackObj };
+}
+function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
+    // Accepts an array of {base: base_spec, releases: [releaseOnChannelA, releaseOnChannelB, ...]} objects,
+    // returning the releasOnChannelX releases array corresponding to the specified base
+    //
+    // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
+    const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
+    const releasesArray = baseReleaseArray[i].releases;
+    // console.log(`Found releases ${base} at index ${i}: ${JSON.stringify(releasesArray)}`);
+    return { i, releases: releasesArray };
+}
+function getReleaseFromReleaseArrayByChannel(releases, channel) {
+    // console.log(`releases: ${JSON.stringify(releases)}`)
+    const i = releases.findIndex((release) => release.channel === channel);
+    const releaseObj = releases[i];
+    // console.log(`Found release for channel ${channel} at index ${i}: ${JSON.stringify(releaseObj)}`);
+    return { i, release: releaseObj };
+}
+function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
+    // Returns the release in an array of releases for a given channel, handling any null releases
+    //
+    // Some charmhub releases "point" to another release, for example:
+    //    `charmcraft status metacontroller-operator`:
+    //        Track    Base                  Channel                    Version    Revision    Expires at
+    //        latest   ubuntu 20.04 (amd64)  stable                      2          2
+    //                                       candidate                   5          5
+    //                                       beta                        ↑          ↑
+    //                                       edge                       13         13
+    //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
+    //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
+    //        0.3      -                     stable                      -          -
+    //                                       candidate                   -          -
+    //                                       beta                        -          -
+    //                                       edge                        -          -
+    // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
+    // `charmcraft status charmName --format json` returns these pointer releases with
+    // `release.status == tracking` and `release.revision == null`.
+    // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
+    // check candidate).
+    //
+    // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
+    // an error for this case.  This situation is identified by `release.status == closed`.
+    const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
+    if (release.status === 'open') {
+        // Release exists.  Return it
+        return { i, release };
+    }
+    if (release.status === 'tracking') {
+        // Pointer to a safer channel.  Return that instead
+        const saferChannel = getSaferChannel(channel);
+        return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
+    }
+    if (release.status === 'closed') {
+        // No release exists.  Throw
+        throw new Error(`No revision available in channel ${channel}`);
+    }
+    throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
+}
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
@@ -21807,6 +21893,13 @@ class Charmcraft {
             return result.stdout;
         });
     }
+    statusJson(charm) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const parsedObj = JSON.parse(result.stdout);
+            return parsedObj;
+        });
+    }
     getRevisionInfoFromChannel(charm, track, channel) {
         return __awaiter(this, void 0, void 0, function* () {
             // For now we have to parse the `charmcraft status` output this will soon be fixed
@@ -21849,6 +21942,28 @@ class Charmcraft {
                 }
             }
             throw new Error(`No track with name ${track}`);
+        });
+    }
+    getRevisionInfoFromChannel_json(charm, track, channel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
+            if (!acceptedChannels.includes(channel)) {
+                throw new Error(`Provided channel ${channel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
+            }
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const { track: trackObj } = getTrackByName(charmcraftStatus, track);
+            // TODO: make base an input arg
+            const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
+            const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
+            if (releasesArray === null) {
+                throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
+            }
+            // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
+            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            const { revision } = releaseObj;
+            const { resources } = releaseObj;
+            return { charmRev: revision, resources };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21726,7 +21726,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     }
     if (release.status === 'closed') {
         // No release exists.  Throw
-        throw new Error(`No revision available in channel ${channel}`);
+        throw new Error(`No revision available in risk level ${channel}`);
     }
     throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
 }
@@ -21959,9 +21959,19 @@ class Charmcraft {
             }
             // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
             const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
-            return { charmRev: revision, resources };
+            // console.log(`resources: ${JSON.stringify(resources)}`);
+            const resourceInfoArray = [];
+            for (let i = 0; i < resources.length; i += 1) {
+                // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
+                resourceInfoArray.push({
+                    resourceName: resources[i].name,
+                    resourceRev: resources[i].revision,
+                });
+            }
+            return { charmRev: revision, resources: resourceInfoArray };
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21944,7 +21944,7 @@ class Charmcraft {
             throw new Error(`No track with name ${track}`);
         });
     }
-    getRevisionInfoFromChannel_json(charm, track, channel) {
+    getRevisionInfoFromChannelJson(charm, track, channel, base) {
         return __awaiter(this, void 0, void 0, function* () {
             const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
             if (!acceptedChannels.includes(channel)) {
@@ -21953,8 +21953,6 @@ class Charmcraft {
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
-            // TODO: make base an input arg
-            const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {
                 throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21658,13 +21658,16 @@ function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
     const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+    // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
     const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    if (iLessRisky > 0) {
+    // console.log(`found less risky channel is at index ${iLessRisky}`);
+    if (iLessRisky >= 0) {
         return orderedChannels[iLessRisky];
     }
     return '';
 }
 function getTrackByName(trackArray, track) {
+    // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
     const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
     if (i === -1) {
         throw new Error(`No track with name ${track}`);
@@ -21714,7 +21717,9 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     //
     // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
     // an error for this case.  This situation is identified by `release.status == closed`.
+    // console.log(`releaseArray: ${JSON.stringify(releases)}`);
     const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
+    // console.log(`release: ${JSON.stringify(release)}`);
     if (release.status === 'open') {
         // Release exists.  Return it
         return { i, release };
@@ -21722,6 +21727,10 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
     if (release.status === 'tracking') {
         // Pointer to a safer channel.  Return that instead
         const saferChannel = getSaferChannel(channel);
+        if (saferChannel === '') {
+            // no safer channel exists.  Should we throw?
+            throw new Error(`release.status == tracking for channel ${channel}, but no safer channel exists`);
+        }
         return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
     }
     if (release.status === 'closed') {
@@ -21952,6 +21961,7 @@ class Charmcraft {
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
+            // console.log(`charmcraftStatus: ${charmcraftStatus}`);
             const { track: trackObj } = getTrackByName(charmcraftStatus, track);
             const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
             if (releasesArray === null) {

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21644,65 +21644,6 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
-function getSaferChannel(channel) {
-    // Returns name of the next less risky channel, or an empty string if none exist
-    // standard channel names, from least to most risk
-    const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-    if (iLessRisky >= 0) {
-        return orderedChannels[iLessRisky];
-    }
-    return '';
-}
-function getReleaseFromReleaseArrayByChannel(releases, channel) {
-    const i = releases.findIndex((release) => release.channel === channel);
-    const releaseObj = releases[i];
-    return { i, release: releaseObj };
-}
-function getReleaseFromReleaseArrayByChannelHandlingNull(releases, channel) {
-    // Returns the release in an array of releases for a given channel, handling any null releases
-    //
-    // Some charmhub releases "point" to another release, for example:
-    //    `charmcraft status metacontroller-operator`:
-    //        Track    Base                  Channel                    Version    Revision    Expires at
-    //        latest   ubuntu 20.04 (amd64)  stable                      2          2
-    //                                       candidate                   5          5
-    //                                       beta                        ↑          ↑
-    //                                       edge                       13         13
-    //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
-    //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
-    //        0.3      -                     stable                      -          -
-    //                                       candidate                   -          -
-    //                                       beta                        -          -
-    //                                       edge                        -          -
-    // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
-    // `charmcraft status charmName --format json` returns these pointer releases with
-    // `release.status == tracking` and `release.revision == null`.
-    // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
-    // check candidate).
-    //
-    // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
-    // an error for this case.  This situation is identified by `release.status == closed`.
-    const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-    if (release.status === 'open') {
-        // Release exists.  Return it
-        return { i, release };
-    }
-    if (release.status === 'tracking') {
-        // Pointer to a safer channel.  Return that instead
-        const saferChannel = getSaferChannel(channel);
-        if (saferChannel === '') {
-            // no safer channel exists.  Should we throw?
-            throw new Error(`release.status == tracking for channel ${channel}, but no safer channel exists`);
-        }
-        return getReleaseFromReleaseArrayByChannelHandlingNull(releases, saferChannel);
-    }
-    if (release.status === 'closed') {
-        // No release exists.  Throw
-        throw new Error(`No revision available in risk level ${channel}`);
-    }
-    throw new Error(`Found unknown release status ${release.status} in charmcraft status results`);
-}
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
@@ -21936,13 +21877,15 @@ class Charmcraft {
             if (channelIndex === -1) {
                 throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
             }
-            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === targetChannel);
+            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
             if (releaseIndex === -1) {
                 throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
             }
-            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(charmcraftStatus[trackIndex].channels[channelIndex].releases, targetChannel);
-            const { revision } = releaseObj;
-            const { resources } = releaseObj;
+            const releaseObj = charmcraftStatus[trackIndex].channels[channelIndex].releases[releaseIndex];
+            if (releaseObj.status !== 'open') {
+                throw new Error('Channel is not open. Make sure there was a release made to this channel previously.');
+            }
+            const { revision, resources } = releaseObj;
             const resourceInfoArray = [];
             for (let i = 0; i < resources.length; i += 1) {
                 resourceInfoArray.push({

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21644,16 +21644,6 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
 /* eslint-disable camelcase */
-function checkIfIsBase(baseRelease, base) {
-    const { name, channel: baseChannel, architecture } = base;
-    if (baseRelease.base === null) {
-        // This release has no base.  Nothing is here
-        return false;
-    }
-    return (baseRelease.base.name === name &&
-        baseRelease.base.channel === baseChannel &&
-        baseRelease.base.architecture === architecture);
-}
 function getSaferChannel(channel) {
     // Returns name of the next less risky channel, or an empty string if none exist
     // standard channel names, from least to most risk
@@ -21663,23 +21653,6 @@ function getSaferChannel(channel) {
         return orderedChannels[iLessRisky];
     }
     return '';
-}
-function getTrackByName(trackArray, track) {
-    const i = trackArray.findIndex((trackStatus) => trackStatus.track === track);
-    if (i === -1) {
-        throw new Error(`No track with name ${track}`);
-    }
-    const trackObj = trackArray[i];
-    return { i, track: trackObj };
-}
-function getReleasesFromReleaseBaseArrayByBase(baseReleaseArray, base) {
-    // Accepts an array of {base: base_spec, releases: [releaseOnChannelA, releaseOnChannelB, ...]} objects,
-    // returning the releasOnChannelX releases array corresponding to the specified base
-    //
-    // base should be of format {name: 'ubuntu', channel: '20.04', architecture: 'amd64'}
-    const i = baseReleaseArray.findIndex((baseRelease) => checkIfIsBase(baseRelease, base));
-    const releasesArray = baseReleaseArray[i].releases;
-    return { i, releases: releasesArray };
 }
 function getReleaseFromReleaseArrayByChannel(releases, channel) {
     const i = releases.findIndex((release) => release.channel === channel);
@@ -21944,24 +21917,30 @@ class Charmcraft {
             throw new Error(`No track with name ${track}`);
         });
     }
-    getRevisionInfoFromChannelJson(charm, track, channel, base) {
+    getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
             const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(channel)) {
-                throw new Error(`Provided channel ${channel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
+            if (!acceptedChannels.includes(targetChannel)) {
+                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
             }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
-            const { track: trackObj } = getTrackByName(charmcraftStatus, track);
-            // const trackObj = charmcraftStatus.filter((obj: any) => obj.track === track)
-            // const channelWithSpecifiedBase = trackObj.filter((releaseChannel: any) => releaseChannel.base.name === base.name && releaseChannel.base.channel === base.channel && releaseChannel.base.architecture === base.architecture)
-            // const targetRelease = channelWithSpecifiedBase.releases.filter((release: any) => release.channel === channel)
-            const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(trackObj.channels, base);
-            if (releasesArray === null) {
-                throw new Error(`Cannot find release for charm ${charm}, track ${track}, channel ${channel}, with base ${JSON.stringify(base)}`);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
             }
-            // console.log(`releasesArray in main: ${JSON.stringify(releasesArray)}`);
-            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
+            const channelIndex = charmcraftStatus[trackIndex].channels.findIndex((channel) => channel.base &&
+                channel.base.name === targetBase.name &&
+                channel.base.channel === targetBase.channel &&
+                channel.base.architecture === targetBase.architecture);
+            if (channelIndex === -1) {
+                throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
+            }
+            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === targetChannel);
+            if (releaseIndex === -1) {
+                throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
+            }
+            const { release: releaseObj } = getReleaseFromReleaseArrayByChannelHandlingNull(charmcraftStatus[trackIndex].channels[channelIndex].releases, targetChannel);
             const { revision } = releaseObj;
             const { resources } = releaseObj;
             const resourceInfoArray = [];

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21870,18 +21870,18 @@ class Charmcraft {
             if (trackIndex === -1) {
                 throw new Error(`No track with name ${targetTrack}`);
             }
-            const channelIndex = charmcraftStatus[trackIndex].channels.findIndex((channel) => channel.base &&
+            const mappingIndex = charmcraftStatus[trackIndex].mappings.findIndex((channel) => channel.base &&
                 channel.base.name === targetBase.name &&
                 channel.base.channel === targetBase.channel &&
                 channel.base.architecture === targetBase.architecture);
-            if (channelIndex === -1) {
+            if (mappingIndex === -1) {
                 throw new Error(`No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`);
             }
-            const releaseIndex = charmcraftStatus[trackIndex].channels[channelIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
+            const releaseIndex = charmcraftStatus[trackIndex].mappings[mappingIndex].releases.findIndex((release) => release.channel === `${targetTrack}/${targetChannel}`);
             if (releaseIndex === -1) {
                 throw new Error(`Cannot find release with channel name ${targetChannel}, with base`);
             }
-            const releaseObj = charmcraftStatus[trackIndex].channels[channelIndex].releases[releaseIndex];
+            const releaseObj = charmcraftStatus[trackIndex].mappings[mappingIndex].releases[releaseIndex];
             if (releaseObj.status !== 'open') {
                 throw new Error('Channel is not open. Make sure there was a release made to this channel previously.');
             }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:release-charm": "ncc build src/entries/release-charm.ts -o dist/release-charm",
     "test": "jest",
     "lint": "eslint ./src --ext .js,.ts",
+    "lint:fix": "eslint ./src --ext .js,.ts --fix",
     "format": "prettier ./src -c",
     "format:fix": "prettier ./src -w",
     "prepare": "husky install"

--- a/release-charm/README.md
+++ b/release-charm/README.md
@@ -16,10 +16,25 @@ on:
       origin-channel:
         description: 'Origin Channel'
         required: true
+
       # for multi charm repo
       charm-name:
         description: 'Charm Name'
         required: true
+
+      # for specifying a different base
+      base-name:
+        description: 'Charmcraft Base Name'
+        required: true
+        default: ''
+      base-channel:
+        description: 'Charmcraft Base Channel'
+        required: true
+        default: ''
+      base-architecture:
+        description: 'Charmcraft Base Architecture'
+        required: true
+        default: ''
 jobs:
   promote-charm:
     name: Promote charm
@@ -33,14 +48,22 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
+
           # for multi charm repo
           tag-prefix: ${{ github.event.inputs.charm-name }}
-          charm-path: charms/${{ github.event.inputs.charm-name}}
+          charm-path: charms/${{ github.event.inputs.charm-name }}
+
+          # for specifying a different base
+          base-name: ${{ github.event.inputs.base-name }}
+          base-channel: ${{ github.event.inputs.base-channel }}
+          base-architecture: ${{ github.event.inputs.base-architecture }}
 ```
 
 ![Manual dispatch release charm action form screenshot](dispatch_release_action_form.png "Manual dispatch release charm action form screenshot")
 
 In multi charm repo, you would also need to provide the charm path and tag prefix (same tag prefix used in `upload-charm` action) for the specific charm you are releasing. By convention, it should be the same the name of the charm. The example yaml provided above should work for must multi charm repo setup.
+
+For charms with a different default base or are built on multiple bases, you could add additional inputs in your github workflow yaml. You could also utilize github action's `default` field to set your charm's specific default base information.
 ## API
 
 ### Inputs
@@ -51,8 +74,11 @@ In multi charm repo, you would also need to provide the charm path and tag prefi
 | `github-token`       | Github Token needed for automatic tagging when publishing                                               | ✔️       |
 | `destination-channel`| Channel to which the charm will be released. It must be in the format of `track/risk`.                  | ✔️       |
 | `origin-channel`     | Origin Channel from where the charm that needs to be promoted will be pulled.                           | ✔️       |
+| `base-name`          | Charm's Charmcraft base name. Default to `ubuntu`.                                                      |          |
+| `base-channel`       | Charm's Charmcraft base channel. Default to `20.04`.                                                    |          |
+| `base-architecture`  | Charm's Charmcraft base architecture. Default to `amd64`.                                               |          |
 | `tag-prefix`         | Tag prefix, useful when bundling multiple charms in the same repo using a matrix.                       |          |     
-| `charm-path`         | Path to the charm where `metadata.yaml` is located. Defaults to the current working directory.      |          |    
+| `charm-path`         | Path to the charm where `metadata.yaml` is located. Defaults to the current working directory.          |          |    
 | `charmcraft-channel` | Snap channel to use when installing charmcraft. Defaults to `latest/edge`.                              |          |
 
 ### Outputs
@@ -60,7 +86,5 @@ In multi charm repo, you would also need to provide the charm path and tag prefi
 None
 
 ### Limitations
-- Doesn't work with charm that are built on multiple bases
 - The origin channel must be in the format of `track/risk` for parsing the charmcraft status output.
 - Only works for charm. It does not support releasing bundles.
-- Does not support charm with channel branches as it would mess up the charmcraft status output.

--- a/release-charm/action.yaml
+++ b/release-charm/action.yaml
@@ -11,7 +11,7 @@ inputs:
     required: true
     description: |
       Origin Channel from where the charm that needs to be promoted will be
-      pulled unless `revision` is set.
+      pulled.
   base-name:
     required: true
     description: |

--- a/release-charm/action.yaml
+++ b/release-charm/action.yaml
@@ -12,6 +12,21 @@ inputs:
     description: |
       Origin Channel from where the charm that needs to be promoted will be
       pulled unless `revision` is set.
+  base-name:
+    required: true
+    description: |
+      Charmcraft Base Name
+    default: 'ubuntu'
+  base-channel:
+    required: true
+    description: |
+      Charmcraft Base Channel
+    default: '20.04'
+  base-architecture:
+    required: true
+    description: |
+      Charmcraft Base Architecture
+    default: 'amd64'
   tag-prefix:
     required: false
     description: |

--- a/src/actions/release-charm/release-charm.ts
+++ b/src/actions/release-charm/release-charm.ts
@@ -10,6 +10,9 @@ export class ReleaseCharmAction {
 
   private destinationChannel: string;
   private originChannel: string;
+  private baseName: string;
+  private baseChannel: string;
+  private baseArchitecture: string;
 
   private charmcraftChannel: string;
   private token: string;
@@ -19,6 +22,9 @@ export class ReleaseCharmAction {
   constructor() {
     this.destinationChannel = core.getInput('destination-channel');
     this.originChannel = core.getInput('origin-channel');
+    this.baseName = core.getInput('base-name');
+    this.baseChannel = core.getInput('base-channel');
+    this.baseArchitecture = core.getInput('base-architecture');
     this.charmcraftChannel = core.getInput('charmcraft-channel');
     this.token = core.getInput('github-token');
     this.tagPrefix = core.getInput('tag-prefix');
@@ -41,8 +47,11 @@ export class ReleaseCharmAction {
 
       const [originTrack, originChannel] = this.originChannel.split('/');
 
-      // TODO: Handle base more robustly
-      const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
+      const base = {
+        name: this.baseName,
+        channel: this.baseChannel,
+        architecture: this.baseArchitecture,
+      };
 
       const { charmRev, resources } =
         await this.charmcraft.getRevisionInfoFromChannelJson(

--- a/src/actions/release-charm/release-charm.ts
+++ b/src/actions/release-charm/release-charm.ts
@@ -41,11 +41,15 @@ export class ReleaseCharmAction {
 
       const [originTrack, originChannel] = this.originChannel.split('/');
 
+      // TODO: Handle base more robustly
+      const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
+
       const { charmRev, resources } =
-        await this.charmcraft.getRevisionInfoFromChannel(
+        await this.charmcraft.getRevisionInfoFromChannelJson(
           charmName,
           originTrack,
-          originChannel
+          originChannel,
+          base
         );
 
       await this.charmcraft.release(

--- a/src/services/charmcraft/charmcraft.test.ts
+++ b/src/services/charmcraft/charmcraft.test.ts
@@ -308,7 +308,7 @@ describe('the charmcraft service', () => {
     });
   });
 
-  describe.only('test getRevisionFromChannelJson', () => {
+  describe('test getRevisionFromChannelJson', () => {
     describe('returns correct revision details', () => {
       it('with one base in track', async () => {
         const charmcraftStatus = [
@@ -556,6 +556,29 @@ describe('the charmcraft service', () => {
     });
 
     describe('throws correct error', () => {
+      it('when an invalid channel was provided', async () => {
+        const base = {
+          name: 'ubuntu',
+          channel: '20.04',
+          architecture: 'amd64',
+        };
+
+        const charmcraft = new Charmcraft('token');
+
+        await expect(
+          charmcraft.getRevisionInfoFromChannelJson(
+            'placeholder-charm',
+            'valid track',
+            'invalid-channel',
+            base
+          )
+        ).rejects.toThrow(
+          Error(
+            `Provided channel invalid-channel is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`
+          )
+        );
+      });
+
       it('when track not found', async () => {
         const charmcraftStatus = [{ track: 'special-track' }];
         const track = 'latest';
@@ -661,7 +684,11 @@ describe('the charmcraft service', () => {
             channel,
             base
           )
-        ).rejects.toThrow(Error());
+        ).rejects.toThrow(
+          Error(
+            `No channel with base name ${base.name}, base channel ${base.channel} and base architecture ${base.architecture}`
+          )
+        );
       });
 
       it('when release cannot be found', async () => {

--- a/src/services/charmcraft/charmcraft.test.ts
+++ b/src/services/charmcraft/charmcraft.test.ts
@@ -324,7 +324,7 @@ describe('the charmcraft service', () => {
                 releases: [
                   {
                     status: 'closed',
-                    channel: 'stable',
+                    channel: 'latest/stable',
                     version: null,
                     revision: null,
                     resources: null,
@@ -332,7 +332,7 @@ describe('the charmcraft service', () => {
                   },
                   {
                     status: 'open',
-                    channel: 'candidate',
+                    channel: 'latest/candidate',
                     version: '3',
                     revision: 3,
                     resources: [
@@ -345,7 +345,7 @@ describe('the charmcraft service', () => {
                   },
                   {
                     status: 'open',
-                    channel: 'beta',
+                    channel: 'latest/beta',
                     version: '10',
                     revision: 10,
                     resources: [
@@ -358,7 +358,7 @@ describe('the charmcraft service', () => {
                   },
                   {
                     status: 'open',
-                    channel: 'edge',
+                    channel: 'latest/edge',
                     version: '10',
                     revision: 10,
                     resources: [
@@ -418,7 +418,7 @@ describe('the charmcraft service', () => {
                 releases: [
                   {
                     status: 'open',
-                    channel: 'edge',
+                    channel: 'latest/edge',
                     version: '10',
                     revision: 10,
                     resources: [
@@ -440,7 +440,7 @@ describe('the charmcraft service', () => {
                 releases: [
                   {
                     status: 'open',
-                    channel: 'edge',
+                    channel: 'latest/edge',
                     version: '5',
                     revision: 5,
                     resources: [
@@ -467,74 +467,6 @@ describe('the charmcraft service', () => {
         const expected = {
           charmRev: '10',
           resources: [{ resourceName: 'httpbin-image', resourceRev: '10' }],
-        };
-
-        const charmcraft = new Charmcraft('token');
-
-        jest.spyOn(exec, 'getExecOutput').mockResolvedValue({
-          exitCode: 0,
-          stderr: '',
-          stdout: JSON.stringify(charmcraftStatus),
-        });
-
-        const result = await charmcraft.getRevisionInfoFromChannelJson(
-          'placeholder-charm',
-          track,
-          channel,
-          base
-        );
-        expect(result).toEqual(expected);
-      });
-
-      it('returns results from a safer channel given the chosen channel is in tracking status', async () => {
-        const charmcraftStatus = [
-          {
-            track: 'latest',
-            channels: [
-              {
-                base: {
-                  name: 'ubuntu',
-                  channel: '20.04',
-                  architecture: 'amd64',
-                },
-                releases: [
-                  {
-                    status: 'open',
-                    channel: 'beta',
-                    version: '9',
-                    revision: 9,
-                    resources: [
-                      {
-                        name: 'httpbin-image',
-                        revision: 9,
-                      },
-                    ],
-                    expires_at: null,
-                  },
-                  {
-                    status: 'tracking',
-                    channel: 'edge',
-                    version: null,
-                    revision: null,
-                    resources: null,
-                    expires_at: null,
-                  },
-                ],
-              },
-            ],
-          },
-        ];
-
-        const track = 'latest';
-        const channel = 'edge';
-        const base = {
-          name: 'ubuntu',
-          channel: '20.04',
-          architecture: 'amd64',
-        };
-        const expected = {
-          charmRev: '9',
-          resources: [{ resourceName: 'httpbin-image', resourceRev: '9' }],
         };
 
         const charmcraft = new Charmcraft('token');
@@ -649,7 +581,7 @@ describe('the charmcraft service', () => {
         ).rejects.toThrowError();
       });
 
-      it('when there are no channels with base', async () => {
+      it('when channel base is null', async () => {
         const charmcraftStatus = [
           {
             track: 'latest',
@@ -702,7 +634,7 @@ describe('the charmcraft service', () => {
                   channel: '20.04',
                   architecture: 'amd64',
                 },
-                releases: [{ channel: 'beta' }],
+                releases: [{ channel: 'latest/beta' }],
               },
             ],
           },
@@ -733,7 +665,7 @@ describe('the charmcraft service', () => {
         ).rejects.toThrowError();
       });
 
-      it('when release is closed', async () => {
+      it('when release channel is closed', async () => {
         const charmcraftStatus = [
           {
             track: 'latest',
@@ -744,7 +676,7 @@ describe('the charmcraft service', () => {
                   channel: '20.04',
                   architecture: 'amd64',
                 },
-                releases: [{ channel: 'edge', status: 'closed' }],
+                releases: [{ channel: 'latest/edge', status: 'closed' }],
               },
             ],
           },
@@ -773,11 +705,13 @@ describe('the charmcraft service', () => {
             base
           )
         ).rejects.toThrow(
-          Error(`No revision available in risk level ${channel}`)
+          Error(
+            'Channel is not open. Make sure there was a release made to this channel previously.'
+          )
         );
       });
 
-      it('when no safer channel is found', async () => {
+      it('when release is closed', async () => {
         const charmcraftStatus = [
           {
             track: 'latest',
@@ -789,21 +723,15 @@ describe('the charmcraft service', () => {
                   architecture: 'amd64',
                 },
                 releases: [
-                  {
-                    status: 'tracking',
-                    channel: 'stable',
-                    version: null,
-                    revision: null,
-                    resources: null,
-                    expires_at: null,
-                  },
+                  { channel: 'latest/beta', status: 'open' },
+                  { channel: 'latest/edge', status: 'tracking' },
                 ],
               },
             ],
           },
         ];
         const track = 'latest';
-        const channel = 'stable';
+        const channel = 'edge';
         const base = {
           name: 'ubuntu',
           channel: '20.04',
@@ -827,7 +755,7 @@ describe('the charmcraft service', () => {
           )
         ).rejects.toThrow(
           Error(
-            `release.status == tracking for channel ${channel}, but no safer channel exists`
+            'Channel is not open. Make sure there was a release made to this channel previously.'
           )
         );
       });

--- a/src/services/charmcraft/charmcraft.test.ts
+++ b/src/services/charmcraft/charmcraft.test.ts
@@ -314,7 +314,7 @@ describe('the charmcraft service', () => {
         const charmcraftStatus = [
           {
             track: 'latest',
-            channels: [
+            mappings: [
               {
                 base: {
                   name: 'ubuntu',
@@ -408,7 +408,7 @@ describe('the charmcraft service', () => {
         const charmcraftStatus = [
           {
             track: 'latest',
-            channels: [
+            mappings: [
               {
                 base: {
                   name: 'ubuntu',
@@ -543,7 +543,7 @@ describe('the charmcraft service', () => {
         const charmcraftStatus = [
           {
             track: 'latest',
-            channels: [
+            mappings: [
               {
                 base: {
                   name: 'ubuntu',
@@ -585,7 +585,7 @@ describe('the charmcraft service', () => {
         const charmcraftStatus = [
           {
             track: 'latest',
-            channels: [
+            mappings: [
               {
                 base: null,
                 releases: [],
@@ -627,7 +627,7 @@ describe('the charmcraft service', () => {
         const charmcraftStatus = [
           {
             track: 'latest',
-            channels: [
+            mappings: [
               {
                 base: {
                   name: 'ubuntu',
@@ -669,7 +669,7 @@ describe('the charmcraft service', () => {
         const charmcraftStatus = [
           {
             track: 'latest',
-            channels: [
+            mappings: [
               {
                 base: {
                   name: 'ubuntu',
@@ -715,7 +715,7 @@ describe('the charmcraft service', () => {
         const charmcraftStatus = [
           {
             track: 'latest',
-            channels: [
+            mappings: [
               {
                 base: {
                   name: 'ubuntu',

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -9,84 +9,6 @@ import { Base, Channel, Status, Track } from './types';
 
 /* eslint-disable camelcase */
 
-function getSaferChannel(channel: string) {
-  // Returns name of the next less risky channel, or an empty string if none exist
-
-  // standard channel names, from least to most risk
-  const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
-
-  const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-
-  if (iLessRisky >= 0) {
-    return orderedChannels[iLessRisky];
-  }
-  return '';
-}
-
-function getReleaseFromReleaseArrayByChannel(releases: any, channel: string) {
-  const i = releases.findIndex((release: any) => release.channel === channel);
-  const releaseObj = releases[i];
-
-  return { i, release: releaseObj };
-}
-
-function getReleaseFromReleaseArrayByChannelHandlingNull(
-  releases: any,
-  channel: string
-): any {
-  // Returns the release in an array of releases for a given channel, handling any null releases
-  //
-  // Some charmhub releases "point" to another release, for example:
-  //    `charmcraft status metacontroller-operator`:
-  //        Track    Base                  Channel                    Version    Revision    Expires at
-  //        latest   ubuntu 20.04 (amd64)  stable                      2          2
-  //                                       candidate                   5          5
-  //                                       beta                        ↑          ↑
-  //                                       edge                       13         13
-  //                                       edge/add-charming-actions   9          9           2022-06-30T01:00:00Z
-  //                                       edge/resources-removal     12         12           2022-07-09T01:00:00Z
-  //        0.3      -                     stable                      -          -
-  //                                       candidate                   -          -
-  //                                       beta                        -          -
-  //                                       edge                        -          -
-  // where we see latest/ubuntu-amd64/beta points to candidate, eg they have the same release.
-  // `charmcraft status charmName --format json` returns these pointer releases with
-  // `release.status == tracking` and `release.revision == null`.
-  // This function handles this case, recursively looking for a "safer" release (eg: if beta is null,
-  // check candidate).
-  //
-  // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
-  // an error for this case.  This situation is identified by `release.status == closed`.
-
-  const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
-
-  if (release.status === 'open') {
-    // Release exists.  Return it
-    return { i, release };
-  }
-  if (release.status === 'tracking') {
-    // Pointer to a safer channel.  Return that instead
-    const saferChannel = getSaferChannel(channel);
-    if (saferChannel === '') {
-      // no safer channel exists.  Should we throw?
-      throw new Error(
-        `release.status == tracking for channel ${channel}, but no safer channel exists`
-      );
-    }
-    return getReleaseFromReleaseArrayByChannelHandlingNull(
-      releases,
-      saferChannel
-    );
-  }
-  if (release.status === 'closed') {
-    // No release exists.  Throw
-    throw new Error(`No revision available in risk level ${channel}`);
-  }
-  throw new Error(
-    `Found unknown release status ${release.status} in charmcraft status results`
-  );
-}
-
 class Charmcraft {
   private uploadImage: boolean;
   private token: string;
@@ -404,7 +326,9 @@ class Charmcraft {
 
     const releaseIndex = charmcraftStatus[trackIndex].channels[
       channelIndex
-    ].releases.findIndex((release: any) => release.channel === targetChannel);
+    ].releases.findIndex(
+      (release: any) => release.channel === `${targetTrack}/${targetChannel}`
+    );
 
     if (releaseIndex === -1) {
       throw new Error(
@@ -412,14 +336,18 @@ class Charmcraft {
       );
     }
 
-    const { release: releaseObj } =
-      getReleaseFromReleaseArrayByChannelHandlingNull(
-        charmcraftStatus[trackIndex].channels[channelIndex].releases,
-        targetChannel
-      );
+    const releaseObj =
+      charmcraftStatus[trackIndex].channels[channelIndex].releases[
+        releaseIndex
+      ];
 
-    const { revision } = releaseObj;
-    const { resources } = releaseObj;
+    if (releaseObj.status !== 'open') {
+      throw new Error(
+        'Channel is not open. Make sure there was a release made to this channel previously.'
+      );
+    }
+
+    const { revision, resources } = releaseObj;
 
     const resourceInfoArray = [] as Array<ResourceInfo>;
 

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 
 import { Metadata, ResourceInfo } from '../../types';
-import { Base, Channel, Status, Track } from './types';
+import { Base, Mapping, Status, Track } from './types';
 
 /* eslint-disable camelcase */
 
@@ -310,22 +310,22 @@ class Charmcraft {
       throw new Error(`No track with name ${targetTrack}`);
     }
 
-    const channelIndex = charmcraftStatus[trackIndex].channels.findIndex(
-      (channel: Channel) =>
+    const mappingIndex = charmcraftStatus[trackIndex].mappings.findIndex(
+      (channel: Mapping) =>
         channel.base &&
         channel.base.name === targetBase.name &&
         channel.base.channel === targetBase.channel &&
         channel.base.architecture === targetBase.architecture
     );
 
-    if (channelIndex === -1) {
+    if (mappingIndex === -1) {
       throw new Error(
         `No channel with base name ${targetBase.name}, base channel ${targetBase.channel} and base architecture ${targetBase.architecture}`
       );
     }
 
-    const releaseIndex = charmcraftStatus[trackIndex].channels[
-      channelIndex
+    const releaseIndex = charmcraftStatus[trackIndex].mappings[
+      mappingIndex
     ].releases.findIndex(
       (release: any) => release.channel === `${targetTrack}/${targetChannel}`
     );
@@ -337,7 +337,7 @@ class Charmcraft {
     }
 
     const releaseObj =
-      charmcraftStatus[trackIndex].channels[channelIndex].releases[
+      charmcraftStatus[trackIndex].mappings[mappingIndex].releases[
         releaseIndex
       ];
 

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -399,10 +399,11 @@ class Charmcraft {
     throw new Error(`No track with name ${track}`);
   }
 
-  async getRevisionInfoFromChannel_json(
+  async getRevisionInfoFromChannelJson(
     charm: string,
     track: string,
-    channel: string
+    channel: string,
+    base: any,
   ): Promise<{ charmRev: string; resources: Array<ResourceInfo> }> {
     const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
     if (!acceptedChannels.includes(channel)) {
@@ -416,8 +417,6 @@ class Charmcraft {
 
     const { track: trackObj } = getTrackByName(charmcraftStatus, track);
 
-    // TODO: make base an input arg
-    const base = { name: 'ubuntu', channel: '20.04', architecture: 'amd64' };
     const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(
       trackObj.channels,
       base

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -115,7 +115,7 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(
   }
   if (release.status === 'closed') {
     // No release exists.  Throw
-    throw new Error(`No revision available in channel ${channel}`);
+    throw new Error(`No revision available in risk level ${channel}`);
   }
   throw new Error(
     `Found unknown release status ${release.status} in charmcraft status results`
@@ -403,7 +403,7 @@ class Charmcraft {
     charm: string,
     track: string,
     channel: string,
-    base: any,
+    base: any
   ): Promise<{ charmRev: string; resources: Array<ResourceInfo> }> {
     const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
     if (!acceptedChannels.includes(channel)) {
@@ -435,10 +435,24 @@ class Charmcraft {
     const { release: releaseObj } =
       getReleaseFromReleaseArrayByChannelHandlingNull(releasesArray, channel);
 
+    // console.log(`releaseObj: ${JSON.stringify(releaseObj)}`);
+
     const { revision } = releaseObj;
     const { resources } = releaseObj;
 
-    return { charmRev: revision, resources };
+    // console.log(`resources: ${JSON.stringify(resources)}`);
+
+    const resourceInfoArray = [] as Array<ResourceInfo>;
+
+    for (let i = 0; i < resources.length; i += 1) {
+      // console.log(`acting for i=${i} and ${JSON.stringify(resources[i])}`);
+      resourceInfoArray.push({
+        resourceName: resources[i].name,
+        resourceRev: resources[i].revision,
+      });
+    }
+
+    return { charmRev: revision, resources: resourceInfoArray };
   }
 
   async release(

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -28,14 +28,17 @@ function getSaferChannel(channel: string) {
 
   // standard channel names, from least to most risk
   const orderedChannels = ['stable', 'candidate', 'beta', 'edge'];
+  // console.log(`looking for safer channel than ${channel} from options ${orderedChannels} (leftmost is safest)`);
   const iLessRisky = orderedChannels.findIndex((c) => c === channel) - 1;
-  if (iLessRisky > 0) {
+  // console.log(`found less risky channel is at index ${iLessRisky}`);
+  if (iLessRisky >= 0) {
     return orderedChannels[iLessRisky];
   }
   return '';
 }
 
 function getTrackByName(trackArray: any, track: string) {
+  // console.log(`trackArray: ${JSON.stringify(trackArray)}`);
   const i = trackArray.findIndex(
     (trackStatus: any) => trackStatus.track === track
   );
@@ -98,9 +101,11 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(
   //
   // This function also handles the case where a track has no release (eg: for track 0.3 above), throwing
   // an error for this case.  This situation is identified by `release.status == closed`.
+  // console.log(`releaseArray: ${JSON.stringify(releases)}`);
 
   const { i, release } = getReleaseFromReleaseArrayByChannel(releases, channel);
 
+  // console.log(`release: ${JSON.stringify(release)}`);
   if (release.status === 'open') {
     // Release exists.  Return it
     return { i, release };
@@ -108,6 +113,12 @@ function getReleaseFromReleaseArrayByChannelHandlingNull(
   if (release.status === 'tracking') {
     // Pointer to a safer channel.  Return that instead
     const saferChannel = getSaferChannel(channel);
+    if (saferChannel === '') {
+      // no safer channel exists.  Should we throw?
+      throw new Error(
+        `release.status == tracking for channel ${channel}, but no safer channel exists`
+      );
+    }
     return getReleaseFromReleaseArrayByChannelHandlingNull(
       releases,
       saferChannel
@@ -414,7 +425,7 @@ class Charmcraft {
 
     // Get status of this charm as a structured object
     const charmcraftStatus = await this.statusJson(charm);
-
+    // console.log(`charmcraftStatus: ${charmcraftStatus}`);
     const { track: trackObj } = getTrackByName(charmcraftStatus, track);
 
     const { releases: releasesArray } = getReleasesFromReleaseBaseArrayByBase(

--- a/src/services/charmcraft/types.ts
+++ b/src/services/charmcraft/types.ts
@@ -1,0 +1,30 @@
+export interface Base {
+  name: string;
+  channel: string;
+  architecture: string;
+}
+
+export interface Resource {
+  name: string;
+  revision: number;
+}
+
+export interface Release {
+  status: 'closed' | 'open' | 'tracking';
+  channel: string;
+  version: string;
+  revision: number;
+  resources: Array<Resource>;
+}
+
+export interface Channel {
+  base: Base;
+  releases: Array<Release>;
+}
+
+export interface Track {
+  track: string;
+  channels: Array<Channel>;
+}
+
+export type Status = Array<Track>;

--- a/src/services/charmcraft/types.ts
+++ b/src/services/charmcraft/types.ts
@@ -17,14 +17,14 @@ export interface Release {
   resources: Array<Resource>;
 }
 
-export interface Channel {
+export interface Mapping {
   base: Base;
   releases: Array<Release>;
 }
 
 export interface Track {
   track: string;
-  channels: Array<Channel>;
+  mappings: Array<Mapping>;
 }
 
 export type Status = Array<Track>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,3 +42,9 @@ export interface ResourceInfo {
   resourceName: string;
   resourceRev: string;
 }
+
+export interface Base {
+  name: string;
+  channel: string;
+  architecture: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,9 +42,3 @@ export interface ResourceInfo {
   resourceName: string;
   resourceRev: string;
 }
-
-export interface Base {
-  name: string;
-  channel: string;
-  architecture: string;
-}


### PR DESCRIPTION
This is a first draft at using `charmcraft status`'s formatted output for the `release-charm` action in order to handle releasing charms that have charmhub branches (see #45 for details on the issue).

This is not the best javascript, but instead a quick hack to get something working.

fixes #45 