### PR TITLE
Enable verbose logging on pack

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21666,7 +21666,7 @@ class Charmcraft {
     }
     pack() {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--destructive-mode', '--verbose'];
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21801,7 +21801,7 @@ class Charmcraft {
     }
     pack() {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--destructive-mode', '--verbose'];
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21749,7 +21749,7 @@ class Charmcraft {
     }
     pack() {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--destructive-mode', '--verbose'];
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21736,7 +21736,7 @@ class Charmcraft {
     }
     pack() {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--destructive-mode', '--verbose'];
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21763,7 +21763,7 @@ class Charmcraft {
     }
     pack() {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--destructive-mode', '--verbose'];
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "charmhub-upload-action",
       "version": "0.2.2",
       "license": "GPL-3.0-only",
       "dependencies": {

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -175,7 +175,7 @@ class Charmcraft {
   }
 
   async pack() {
-    const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+    const args = ['charmcraft', 'pack', '--destructive-mode', '--verbose'];
     await exec('sudo', args, this.execOptions);
   }
 


### PR DESCRIPTION
Currently, if the Charmcraft pack fails, the logs are not uploaded as artefacts - I think displaying the verbose output of the charm pack process in CI is probably preferable?