### PR TITLE
fix: upload resources using digest in upload-charm

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21546,6 +21546,7 @@ const exec_1 = __nccwpck_require__(1514);
 const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
+const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
     constructor(token) {
@@ -21614,7 +21615,9 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
-            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resource_image], this.execOptions);
+            // strip any repository details from the image name, as this will confuse `docker image ls`
+            const resourceImageNameOnly = (0, docker_1.getImageName)(resource_image);
+            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resourceImageNameOnly], this.execOptions);
             const resourceDigests = result.stdout.trim().split('\n');
             if (resourceDigests.length < 1) {
                 throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
@@ -21854,6 +21857,60 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 __exportStar(__nccwpck_require__(6432), exports);
+
+
+/***/ }),
+
+/***/ 9999:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getImageName = void 0;
+/**
+ * Returns a the image name given a container image URI, removing any leading repository info
+ *
+ * For uri's that contain slashes, the text before the first slash is inspected and discarded
+ * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
+ * part of the image name.  This procedure is documented in a note here:
+ * https://www.docker.com/blog/how-to-use-your-own-registry-2/
+ *
+ * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
+ */
+function getImageName(uri) {
+    const uriParts = uri.split('/');
+    if (uriParts.length === 1) {
+        return uri;
+    }
+    if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
+        // First segment of the URI is a registry.  Remove it
+        return uriParts.slice(1).join('/');
+    }
+    return uri;
+}
+exports.getImageName = getImageName;
+
+
+/***/ }),
+
+/***/ 7585:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+__exportStar(__nccwpck_require__(9999), exports);
 
 
 /***/ }),

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21614,13 +21614,25 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
+            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resource_image], this.execOptions);
+            const resourceDigests = result.stdout.trim().split('\n');
+            if (resourceDigests.length < 1) {
+                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
+            }
+            else if (resourceDigests.length > 1) {
+                throw new Error(`Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`);
+            }
+            const resourceDigest = resourceDigests[0];
+            if (resourceDigest.length < 1) {
+                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
+            }
             const args = [
                 'upload-resource',
                 '--quiet',
                 name,
                 resource_name,
                 '--image',
-                resource_image,
+                resourceDigest,
             ];
             yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
         });

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21615,20 +21615,7 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
-            // strip any repository details from the image name, as this will confuse `docker image ls`
-            const resourceImageNameOnly = (0, docker_1.getImageName)(resource_image);
-            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resourceImageNameOnly], this.execOptions);
-            const resourceDigests = result.stdout.trim().split('\n');
-            if (resourceDigests.length < 1) {
-                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
-            }
-            else if (resourceDigests.length > 1) {
-                throw new Error(`Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`);
-            }
-            const resourceDigest = resourceDigests[0];
-            if (resourceDigest.length < 1) {
-                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
-            }
+            const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
                 '--quiet',
@@ -21862,12 +21849,22 @@ __exportStar(__nccwpck_require__(6432), exports);
 /***/ }),
 
 /***/ 9999:
-/***/ ((__unused_webpack_module, exports) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getImageName = void 0;
+exports.getImageDigest = exports.getImageName = void 0;
+const exec_1 = __nccwpck_require__(1514);
 /**
  * Returns a the image name given a container image URI, removing any leading repository info
  *
@@ -21890,6 +21887,30 @@ function getImageName(uri) {
     return uri;
 }
 exports.getImageName = getImageName;
+function getImageDigest(uri) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const imageName = getImageName(uri);
+        const result = yield (0, exec_1.getExecOutput)('docker', [
+            'image',
+            'ls',
+            '-q',
+            imageName,
+        ]);
+        const resourceDigests = result.stdout.trim().split('\n');
+        if (resourceDigests.length < 1) {
+            throw new Error(`No digest found for pulled resource_image '${uri}'`);
+        }
+        else if (resourceDigests.length > 1) {
+            throw new Error(`Found too many digests for pulled resource_image '${uri}'.  Expected single output, got multiline output '${result.stdout}'.`);
+        }
+        const resourceDigest = resourceDigests[0];
+        if (resourceDigest.length < 1) {
+            throw new Error(`No digest found for pulled resource_image '${uri}'`);
+        }
+        return resourceDigest;
+    });
+}
+exports.getImageDigest = getImageDigest;
 
 
 /***/ }),

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21807,20 +21807,7 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
-            // strip any repository details from the image name, as this will confuse `docker image ls`
-            const resourceImageNameOnly = (0, docker_1.getImageName)(resource_image);
-            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resourceImageNameOnly], this.execOptions);
-            const resourceDigests = result.stdout.trim().split('\n');
-            if (resourceDigests.length < 1) {
-                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
-            }
-            else if (resourceDigests.length > 1) {
-                throw new Error(`Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`);
-            }
-            const resourceDigest = resourceDigests[0];
-            if (resourceDigest.length < 1) {
-                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
-            }
+            const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
                 '--quiet',
@@ -22054,12 +22041,22 @@ __exportStar(__nccwpck_require__(6432), exports);
 /***/ }),
 
 /***/ 9999:
-/***/ ((__unused_webpack_module, exports) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getImageName = void 0;
+exports.getImageDigest = exports.getImageName = void 0;
+const exec_1 = __nccwpck_require__(1514);
 /**
  * Returns a the image name given a container image URI, removing any leading repository info
  *
@@ -22082,6 +22079,30 @@ function getImageName(uri) {
     return uri;
 }
 exports.getImageName = getImageName;
+function getImageDigest(uri) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const imageName = getImageName(uri);
+        const result = yield (0, exec_1.getExecOutput)('docker', [
+            'image',
+            'ls',
+            '-q',
+            imageName,
+        ]);
+        const resourceDigests = result.stdout.trim().split('\n');
+        if (resourceDigests.length < 1) {
+            throw new Error(`No digest found for pulled resource_image '${uri}'`);
+        }
+        else if (resourceDigests.length > 1) {
+            throw new Error(`Found too many digests for pulled resource_image '${uri}'.  Expected single output, got multiline output '${result.stdout}'.`);
+        }
+        const resourceDigest = resourceDigests[0];
+        if (resourceDigest.length < 1) {
+            throw new Error(`No digest found for pulled resource_image '${uri}'`);
+        }
+        return resourceDigest;
+    });
+}
+exports.getImageDigest = getImageDigest;
 
 
 /***/ }),

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21806,13 +21806,25 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
+            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resource_image], this.execOptions);
+            const resourceDigests = result.stdout.trim().split('\n');
+            if (resourceDigests.length < 1) {
+                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
+            }
+            else if (resourceDigests.length > 1) {
+                throw new Error(`Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`);
+            }
+            const resourceDigest = resourceDigests[0];
+            if (resourceDigest.length < 1) {
+                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
+            }
             const args = [
                 'upload-resource',
                 '--quiet',
                 name,
                 resource_name,
                 '--image',
-                resource_image,
+                resourceDigest,
             ];
             yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
         });

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21738,6 +21738,7 @@ const exec_1 = __nccwpck_require__(1514);
 const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
+const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
     constructor(token) {
@@ -21806,7 +21807,9 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
-            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resource_image], this.execOptions);
+            // strip any repository details from the image name, as this will confuse `docker image ls`
+            const resourceImageNameOnly = (0, docker_1.getImageName)(resource_image);
+            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resourceImageNameOnly], this.execOptions);
             const resourceDigests = result.stdout.trim().split('\n');
             if (resourceDigests.length < 1) {
                 throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
@@ -22046,6 +22049,60 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 __exportStar(__nccwpck_require__(6432), exports);
+
+
+/***/ }),
+
+/***/ 9999:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getImageName = void 0;
+/**
+ * Returns a the image name given a container image URI, removing any leading repository info
+ *
+ * For uri's that contain slashes, the text before the first slash is inspected and discarded
+ * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
+ * part of the image name.  This procedure is documented in a note here:
+ * https://www.docker.com/blog/how-to-use-your-own-registry-2/
+ *
+ * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
+ */
+function getImageName(uri) {
+    const uriParts = uri.split('/');
+    if (uriParts.length === 1) {
+        return uri;
+    }
+    if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
+        // First segment of the URI is a registry.  Remove it
+        return uriParts.slice(1).join('/');
+    }
+    return uri;
+}
+exports.getImageName = getImageName;
+
+
+/***/ }),
+
+/***/ 7585:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+__exportStar(__nccwpck_require__(9999), exports);
 
 
 /***/ }),

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21637,6 +21637,7 @@ const exec_1 = __nccwpck_require__(1514);
 const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
+const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
     constructor(token) {
@@ -21705,7 +21706,9 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
-            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resource_image], this.execOptions);
+            // strip any repository details from the image name, as this will confuse `docker image ls`
+            const resourceImageNameOnly = (0, docker_1.getImageName)(resource_image);
+            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resourceImageNameOnly], this.execOptions);
             const resourceDigests = result.stdout.trim().split('\n');
             if (resourceDigests.length < 1) {
                 throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
@@ -21945,6 +21948,60 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 __exportStar(__nccwpck_require__(6432), exports);
+
+
+/***/ }),
+
+/***/ 9999:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getImageName = void 0;
+/**
+ * Returns a the image name given a container image URI, removing any leading repository info
+ *
+ * For uri's that contain slashes, the text before the first slash is inspected and discarded
+ * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
+ * part of the image name.  This procedure is documented in a note here:
+ * https://www.docker.com/blog/how-to-use-your-own-registry-2/
+ *
+ * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
+ */
+function getImageName(uri) {
+    const uriParts = uri.split('/');
+    if (uriParts.length === 1) {
+        return uri;
+    }
+    if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
+        // First segment of the URI is a registry.  Remove it
+        return uriParts.slice(1).join('/');
+    }
+    return uri;
+}
+exports.getImageName = getImageName;
+
+
+/***/ }),
+
+/***/ 7585:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+__exportStar(__nccwpck_require__(9999), exports);
 
 
 /***/ }),

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21706,20 +21706,7 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
-            // strip any repository details from the image name, as this will confuse `docker image ls`
-            const resourceImageNameOnly = (0, docker_1.getImageName)(resource_image);
-            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resourceImageNameOnly], this.execOptions);
-            const resourceDigests = result.stdout.trim().split('\n');
-            if (resourceDigests.length < 1) {
-                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
-            }
-            else if (resourceDigests.length > 1) {
-                throw new Error(`Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`);
-            }
-            const resourceDigest = resourceDigests[0];
-            if (resourceDigest.length < 1) {
-                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
-            }
+            const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
                 '--quiet',
@@ -21953,12 +21940,22 @@ __exportStar(__nccwpck_require__(6432), exports);
 /***/ }),
 
 /***/ 9999:
-/***/ ((__unused_webpack_module, exports) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getImageName = void 0;
+exports.getImageDigest = exports.getImageName = void 0;
+const exec_1 = __nccwpck_require__(1514);
 /**
  * Returns a the image name given a container image URI, removing any leading repository info
  *
@@ -21981,6 +21978,30 @@ function getImageName(uri) {
     return uri;
 }
 exports.getImageName = getImageName;
+function getImageDigest(uri) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const imageName = getImageName(uri);
+        const result = yield (0, exec_1.getExecOutput)('docker', [
+            'image',
+            'ls',
+            '-q',
+            imageName,
+        ]);
+        const resourceDigests = result.stdout.trim().split('\n');
+        if (resourceDigests.length < 1) {
+            throw new Error(`No digest found for pulled resource_image '${uri}'`);
+        }
+        else if (resourceDigests.length > 1) {
+            throw new Error(`Found too many digests for pulled resource_image '${uri}'.  Expected single output, got multiline output '${result.stdout}'.`);
+        }
+        const resourceDigest = resourceDigests[0];
+        if (resourceDigest.length < 1) {
+            throw new Error(`No digest found for pulled resource_image '${uri}'`);
+        }
+        return resourceDigest;
+    });
+}
+exports.getImageDigest = getImageDigest;
 
 
 /***/ }),

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21705,13 +21705,25 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
+            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resource_image], this.execOptions);
+            const resourceDigests = result.stdout.trim().split('\n');
+            if (resourceDigests.length < 1) {
+                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
+            }
+            else if (resourceDigests.length > 1) {
+                throw new Error(`Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`);
+            }
+            const resourceDigest = resourceDigests[0];
+            if (resourceDigest.length < 1) {
+                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
+            }
             const args = [
                 'upload-resource',
                 '--quiet',
                 name,
                 resource_name,
                 '--image',
-                resource_image,
+                resourceDigest,
             ];
             yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
         });

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21684,13 +21684,25 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
+            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resource_image], this.execOptions);
+            const resourceDigests = result.stdout.trim().split('\n');
+            if (resourceDigests.length < 1) {
+                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
+            }
+            else if (resourceDigests.length > 1) {
+                throw new Error(`Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`);
+            }
+            const resourceDigest = resourceDigests[0];
+            if (resourceDigest.length < 1) {
+                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
+            }
             const args = [
                 'upload-resource',
                 '--quiet',
                 name,
                 resource_name,
                 '--image',
-                resource_image,
+                resourceDigest,
             ];
             yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
         });

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21616,6 +21616,7 @@ const exec_1 = __nccwpck_require__(1514);
 const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
+const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
     constructor(token) {
@@ -21684,7 +21685,9 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
-            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resource_image], this.execOptions);
+            // strip any repository details from the image name, as this will confuse `docker image ls`
+            const resourceImageNameOnly = (0, docker_1.getImageName)(resource_image);
+            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resourceImageNameOnly], this.execOptions);
             const resourceDigests = result.stdout.trim().split('\n');
             if (resourceDigests.length < 1) {
                 throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
@@ -21924,6 +21927,60 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 __exportStar(__nccwpck_require__(6432), exports);
+
+
+/***/ }),
+
+/***/ 9999:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getImageName = void 0;
+/**
+ * Returns a the image name given a container image URI, removing any leading repository info
+ *
+ * For uri's that contain slashes, the text before the first slash is inspected and discarded
+ * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
+ * part of the image name.  This procedure is documented in a note here:
+ * https://www.docker.com/blog/how-to-use-your-own-registry-2/
+ *
+ * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
+ */
+function getImageName(uri) {
+    const uriParts = uri.split('/');
+    if (uriParts.length === 1) {
+        return uri;
+    }
+    if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
+        // First segment of the URI is a registry.  Remove it
+        return uriParts.slice(1).join('/');
+    }
+    return uri;
+}
+exports.getImageName = getImageName;
+
+
+/***/ }),
+
+/***/ 7585:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+__exportStar(__nccwpck_require__(9999), exports);
 
 
 /***/ }),

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21685,20 +21685,7 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
-            // strip any repository details from the image name, as this will confuse `docker image ls`
-            const resourceImageNameOnly = (0, docker_1.getImageName)(resource_image);
-            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resourceImageNameOnly], this.execOptions);
-            const resourceDigests = result.stdout.trim().split('\n');
-            if (resourceDigests.length < 1) {
-                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
-            }
-            else if (resourceDigests.length > 1) {
-                throw new Error(`Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`);
-            }
-            const resourceDigest = resourceDigests[0];
-            if (resourceDigest.length < 1) {
-                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
-            }
+            const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
                 '--quiet',
@@ -21932,12 +21919,22 @@ __exportStar(__nccwpck_require__(6432), exports);
 /***/ }),
 
 /***/ 9999:
-/***/ ((__unused_webpack_module, exports) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getImageName = void 0;
+exports.getImageDigest = exports.getImageName = void 0;
+const exec_1 = __nccwpck_require__(1514);
 /**
  * Returns a the image name given a container image URI, removing any leading repository info
  *
@@ -21960,6 +21957,30 @@ function getImageName(uri) {
     return uri;
 }
 exports.getImageName = getImageName;
+function getImageDigest(uri) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const imageName = getImageName(uri);
+        const result = yield (0, exec_1.getExecOutput)('docker', [
+            'image',
+            'ls',
+            '-q',
+            imageName,
+        ]);
+        const resourceDigests = result.stdout.trim().split('\n');
+        if (resourceDigests.length < 1) {
+            throw new Error(`No digest found for pulled resource_image '${uri}'`);
+        }
+        else if (resourceDigests.length > 1) {
+            throw new Error(`Found too many digests for pulled resource_image '${uri}'.  Expected single output, got multiline output '${result.stdout}'.`);
+        }
+        const resourceDigest = resourceDigests[0];
+        if (resourceDigest.length < 1) {
+            throw new Error(`No digest found for pulled resource_image '${uri}'`);
+        }
+        return resourceDigest;
+    });
+}
+exports.getImageDigest = getImageDigest;
 
 
 /***/ }),

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21712,20 +21712,7 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
-            // strip any repository details from the image name, as this will confuse `docker image ls`
-            const resourceImageNameOnly = (0, docker_1.getImageName)(resource_image);
-            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resourceImageNameOnly], this.execOptions);
-            const resourceDigests = result.stdout.trim().split('\n');
-            if (resourceDigests.length < 1) {
-                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
-            }
-            else if (resourceDigests.length > 1) {
-                throw new Error(`Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`);
-            }
-            const resourceDigest = resourceDigests[0];
-            if (resourceDigest.length < 1) {
-                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
-            }
+            const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
                 '--quiet',
@@ -21959,12 +21946,22 @@ __exportStar(__nccwpck_require__(6432), exports);
 /***/ }),
 
 /***/ 9999:
-/***/ ((__unused_webpack_module, exports) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getImageName = void 0;
+exports.getImageDigest = exports.getImageName = void 0;
+const exec_1 = __nccwpck_require__(1514);
 /**
  * Returns a the image name given a container image URI, removing any leading repository info
  *
@@ -21987,6 +21984,30 @@ function getImageName(uri) {
     return uri;
 }
 exports.getImageName = getImageName;
+function getImageDigest(uri) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const imageName = getImageName(uri);
+        const result = yield (0, exec_1.getExecOutput)('docker', [
+            'image',
+            'ls',
+            '-q',
+            imageName,
+        ]);
+        const resourceDigests = result.stdout.trim().split('\n');
+        if (resourceDigests.length < 1) {
+            throw new Error(`No digest found for pulled resource_image '${uri}'`);
+        }
+        else if (resourceDigests.length > 1) {
+            throw new Error(`Found too many digests for pulled resource_image '${uri}'.  Expected single output, got multiline output '${result.stdout}'.`);
+        }
+        const resourceDigest = resourceDigests[0];
+        if (resourceDigest.length < 1) {
+            throw new Error(`No digest found for pulled resource_image '${uri}'`);
+        }
+        return resourceDigest;
+    });
+}
+exports.getImageDigest = getImageDigest;
 
 
 /***/ }),

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21711,13 +21711,25 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
+            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resource_image], this.execOptions);
+            const resourceDigests = result.stdout.trim().split('\n');
+            if (resourceDigests.length < 1) {
+                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
+            }
+            else if (resourceDigests.length > 1) {
+                throw new Error(`Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`);
+            }
+            const resourceDigest = resourceDigests[0];
+            if (resourceDigest.length < 1) {
+                throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
+            }
             const args = [
                 'upload-resource',
                 '--quiet',
                 name,
                 resource_name,
                 '--image',
-                resource_image,
+                resourceDigest,
             ];
             yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
         });

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21643,6 +21643,7 @@ const exec_1 = __nccwpck_require__(1514);
 const glob = __importStar(__nccwpck_require__(8090));
 const fs = __importStar(__nccwpck_require__(7147));
 const yaml = __importStar(__nccwpck_require__(1917));
+const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
     constructor(token) {
@@ -21711,7 +21712,9 @@ class Charmcraft {
             if (pullExitCode !== 0) {
                 throw new Error('Could not pull the docker image.');
             }
-            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resource_image], this.execOptions);
+            // strip any repository details from the image name, as this will confuse `docker image ls`
+            const resourceImageNameOnly = (0, docker_1.getImageName)(resource_image);
+            const result = yield (0, exec_1.getExecOutput)('docker', ['image', 'ls', '-q', resourceImageNameOnly], this.execOptions);
             const resourceDigests = result.stdout.trim().split('\n');
             if (resourceDigests.length < 1) {
                 throw new Error(`No digest found for pulled resource_image '${resource_image}'`);
@@ -21951,6 +21954,60 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 __exportStar(__nccwpck_require__(6432), exports);
+
+
+/***/ }),
+
+/***/ 9999:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getImageName = void 0;
+/**
+ * Returns a the image name given a container image URI, removing any leading repository info
+ *
+ * For uri's that contain slashes, the text before the first slash is inspected and discarded
+ * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
+ * part of the image name.  This procedure is documented in a note here:
+ * https://www.docker.com/blog/how-to-use-your-own-registry-2/
+ *
+ * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
+ */
+function getImageName(uri) {
+    const uriParts = uri.split('/');
+    if (uriParts.length === 1) {
+        return uri;
+    }
+    if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
+        // First segment of the URI is a registry.  Remove it
+        return uriParts.slice(1).join('/');
+    }
+    return uri;
+}
+exports.getImageName = getImageName;
+
+
+/***/ }),
+
+/***/ 7585:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+__exportStar(__nccwpck_require__(9999), exports);
 
 
 /***/ }),

--- a/src/services/charmcraft/charmcraft.test.ts
+++ b/src/services/charmcraft/charmcraft.test.ts
@@ -92,6 +92,76 @@ describe('the charmcraft service', () => {
         const mockGetExecOutput = jest.spyOn(exec, 'getExecOutput');
         expect(mockGetExecOutput).not.toHaveBeenCalled();
       });
+
+      describe('pulling images', () => {
+        it('should succeed when image digest is available', () => {
+          const dockerReturn = `somedigest`;
+          const charmcraft = new Charmcraft('token');
+
+          jest.spyOn(exec, 'exec').mockResolvedValue(0);
+
+          jest.spyOn(exec, 'getExecOutput').mockResolvedValue({
+            exitCode: 0,
+            stderr: '',
+            stdout: dockerReturn,
+          });
+
+          charmcraft.uploadResource(
+            'placeholder-image',
+            'placeholder-name',
+            'placeholder-resource-name'
+          );
+          // expect(result).toEqual(expected);
+        });
+
+        it('should throw when digest is empty', () => {
+          const dockerReturn = ``;
+          const charmcraft = new Charmcraft('token');
+
+          jest.spyOn(exec, 'exec').mockResolvedValue(0);
+
+          jest.spyOn(exec, 'getExecOutput').mockResolvedValue({
+            exitCode: 0,
+            stderr: '',
+            stdout: dockerReturn,
+          });
+
+          const expectedError = `No digest found for pulled resource_image 'placeholder-image'`;
+
+          expect(
+            charmcraft.uploadResource(
+              'placeholder-image',
+              'placeholder-name',
+              'placeholder-resource-name'
+            )
+          ).rejects.toThrow(Error(expectedError));
+        });
+
+        it('should throw when digest returns as multiline string', () => {
+          const dockerReturn = `stuff
+          more stuff
+          more stuff`;
+          const charmcraft = new Charmcraft('token');
+
+          jest.spyOn(exec, 'exec').mockResolvedValue(0);
+
+          jest.spyOn(exec, 'getExecOutput').mockResolvedValue({
+            exitCode: 0,
+            stderr: '',
+            stdout: dockerReturn,
+          });
+
+          const expectedError = `Found too many digests for pulled resource_image 'placeholder-image'.  Expected single output, got multiline output '${dockerReturn}'.`;
+
+          expect(
+            charmcraft.uploadResource(
+              'placeholder-image',
+              'placeholder-name',
+              'placeholder-resource-name'
+            )
+          ).rejects.toThrow(Error(expectedError));
+        });
+      }); // is this a mistake?
     });
   });
 

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 
 import { Metadata, ResourceInfo } from '../../types';
+import { getImageName } from '../docker';
 import { Base, Mapping, Status, Track } from './types';
 
 /* eslint-disable camelcase */
@@ -115,9 +116,12 @@ class Charmcraft {
       throw new Error('Could not pull the docker image.');
     }
 
+    // strip any repository details from the image name, as this will confuse `docker image ls`
+    const resourceImageNameOnly = getImageName(resource_image);
+
     const result = await getExecOutput(
       'docker',
-      ['image', 'ls', '-q', resource_image],
+      ['image', 'ls', '-q', resourceImageNameOnly],
       this.execOptions
     );
     const resourceDigests = result.stdout.trim().split('\n');

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 
 import { Metadata, ResourceInfo } from '../../types';
-import { getImageName } from '../docker';
+import { getImageDigest } from '../docker';
 import { Base, Mapping, Status, Track } from './types';
 
 /* eslint-disable camelcase */
@@ -116,31 +116,7 @@ class Charmcraft {
       throw new Error('Could not pull the docker image.');
     }
 
-    // strip any repository details from the image name, as this will confuse `docker image ls`
-    const resourceImageNameOnly = getImageName(resource_image);
-
-    const result = await getExecOutput(
-      'docker',
-      ['image', 'ls', '-q', resourceImageNameOnly],
-      this.execOptions
-    );
-    const resourceDigests = result.stdout.trim().split('\n');
-    if (resourceDigests.length < 1) {
-      throw new Error(
-        `No digest found for pulled resource_image '${resource_image}'`
-      );
-    } else if (resourceDigests.length > 1) {
-      throw new Error(
-        `Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`
-      );
-    }
-    const resourceDigest = resourceDigests[0];
-
-    if (resourceDigest.length < 1) {
-      throw new Error(
-        `No digest found for pulled resource_image '${resource_image}'`
-      );
-    }
+    const resourceDigest = await getImageDigest(resource_image);
 
     const args = [
       'upload-resource',

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -115,13 +115,36 @@ class Charmcraft {
       throw new Error('Could not pull the docker image.');
     }
 
+    const result = await getExecOutput(
+      'docker',
+      ['image', 'ls', '-q', resource_image],
+      this.execOptions
+    );
+    const resourceDigests = result.stdout.trim().split('\n');
+    if (resourceDigests.length < 1) {
+      throw new Error(
+        `No digest found for pulled resource_image '${resource_image}'`
+      );
+    } else if (resourceDigests.length > 1) {
+      throw new Error(
+        `Found too many digests for pulled resource_image '${resource_image}'.  Expected single output, got multiline output '${result.stdout}'.`
+      );
+    }
+    const resourceDigest = resourceDigests[0];
+
+    if (resourceDigest.length < 1) {
+      throw new Error(
+        `No digest found for pulled resource_image '${resource_image}'`
+      );
+    }
+
     const args = [
       'upload-resource',
       '--quiet',
       name,
       resource_name,
       '--image',
-      resource_image,
+      resourceDigest,
     ];
     await exec('charmcraft', args, this.execOptions);
   }

--- a/src/services/docker/docker.test.ts
+++ b/src/services/docker/docker.test.ts
@@ -1,6 +1,79 @@
-import { getImageName } from './docker';
+import * as exec from '@actions/exec';
+import { getImageDigest, getImageName } from './docker';
 
 describe('the container image service', () => {
+  [
+    {
+      uri: 'username/imagename:tag',
+      expectedName: 'username/imagename:tag',
+    },
+    {
+      uri: 'repo.url/username/imagename:tag',
+      expectedName: 'username/imagename:tag',
+    },
+    {
+      uri: 'localhost:port/username/imagename:tag',
+      expectedName: 'username/imagename:tag',
+    },
+    {
+      uri: 'imagename:tag',
+      expectedName: 'imagename:tag',
+    },
+  ].forEach(({ uri, expectedName }) => {
+    it(`should return the correct image name`, () => {
+      expect(getImageName(uri)).toEqual(expectedName);
+    });
+  });
+
+  it('should return a digest it available', async () => {
+    const dockerReturn = `somedigest`;
+
+    jest.spyOn(exec, 'getExecOutput').mockResolvedValue({
+      exitCode: 0,
+      stderr: '',
+      stdout: dockerReturn,
+    });
+
+    const digest = await getImageDigest('placeholder-image');
+    expect(digest).toEqual(dockerReturn);
+  });
+
+  it('should throw when digest is empty', async () => {
+    const dockerReturn = ``;
+
+    jest.spyOn(exec, 'getExecOutput').mockResolvedValue({
+      exitCode: 0,
+      stderr: '',
+      stdout: dockerReturn,
+    });
+
+    const expectedError = `No digest found for pulled resource_image 'placeholder-image'`;
+
+    await expect(getImageDigest('placeholder-image')).rejects.toThrow(
+      Error(expectedError)
+    );
+  });
+
+  it('should throw when digest returns as multiline string', async () => {
+    const dockerReturn = `stuff
+        more stuff
+        more stuff`;
+
+    jest.spyOn(exec, 'exec').mockResolvedValue(0);
+
+    jest.spyOn(exec, 'getExecOutput').mockResolvedValue({
+      exitCode: 0,
+      stderr: '',
+      stdout: dockerReturn,
+    });
+
+    const expectedError = `Found too many digests for pulled resource_image 'placeholder-image'.  Expected single output, got multiline output '${dockerReturn}'.`;
+
+    await expect(getImageDigest('placeholder-image')).rejects.toThrow(
+      Error(expectedError)
+    );
+  });
+
   [
     {
       uri: 'username/imagename:tag',

--- a/src/services/docker/docker.test.ts
+++ b/src/services/docker/docker.test.ts
@@ -1,0 +1,26 @@
+import { getImageName } from './docker';
+
+describe('the container image service', () => {
+  [
+    {
+      uri: 'username/imagename:tag',
+      expectedName: 'username/imagename:tag',
+    },
+    {
+      uri: 'repo.url/username/imagename:tag',
+      expectedName: 'username/imagename:tag',
+    },
+    {
+      uri: 'localhost:port/username/imagename:tag',
+      expectedName: 'username/imagename:tag',
+    },
+    {
+      uri: 'imagename:tag',
+      expectedName: 'imagename:tag',
+    },
+  ].forEach(({ uri, expectedName }) => {
+    it(`should return the correct image name`, () => {
+      expect(getImageName(uri)).toEqual(expectedName);
+    });
+  });
+});

--- a/src/services/docker/docker.ts
+++ b/src/services/docker/docker.ts
@@ -1,3 +1,5 @@
+import { getExecOutput } from '@actions/exec';
+
 /**
  * Returns a the image name given a container image URI, removing any leading repository info
  *
@@ -8,7 +10,7 @@
  *
  * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
  */
-export function getImageName(uri: string) {
+export function getImageName(uri: string): string {
   const uriParts = uri.split('/');
   if (uriParts.length === 1) {
     return uri;
@@ -18,4 +20,30 @@ export function getImageName(uri: string) {
     return uriParts.slice(1).join('/');
   }
   return uri;
+}
+
+export async function getImageDigest(uri: string): Promise<string> {
+  const imageName = getImageName(uri);
+
+  const result = await getExecOutput('docker', [
+    'image',
+    'ls',
+    '-q',
+    imageName,
+  ]);
+  const resourceDigests = result.stdout.trim().split('\n');
+  if (resourceDigests.length < 1) {
+    throw new Error(`No digest found for pulled resource_image '${uri}'`);
+  } else if (resourceDigests.length > 1) {
+    throw new Error(
+      `Found too many digests for pulled resource_image '${uri}'.  Expected single output, got multiline output '${result.stdout}'.`
+    );
+  }
+  const resourceDigest = resourceDigests[0];
+
+  if (resourceDigest.length < 1) {
+    throw new Error(`No digest found for pulled resource_image '${uri}'`);
+  }
+
+  return resourceDigest;
 }

--- a/src/services/docker/docker.ts
+++ b/src/services/docker/docker.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns a the image name given a container image URI, removing any leading repository info
+ *
+ * For uri's that contain slashes, the text before the first slash is inspected and discarded
+ * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
+ * part of the image name.  This procedure is documented in a note here:
+ * https://www.docker.com/blog/how-to-use-your-own-registry-2/
+ *
+ * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
+ */
+export function getImageName(uri: string) {
+  const uriParts = uri.split('/');
+  if (uriParts.length === 1) {
+    return uri;
+  }
+  if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
+    // First segment of the URI is a registry.  Remove it
+    return uriParts.slice(1).join('/');
+  }
+  return uri;
+}

--- a/src/services/docker/index.ts
+++ b/src/services/docker/index.ts
@@ -1,0 +1,1 @@
+export * from './docker';


### PR DESCRIPTION
This change adds a step of extracting an image's digest from
docker and then calling `charmcraft upload-resource`
with that digest rather than the image name.
This conforms with charmcraft's expected usage:
https://discourse.charmhub.io/t/charmcrafts-upload-resource-command/4580

Fixes #67

[This action run](https://github.com/canonical/kubeflow-profiles-operator/actions/runs/3236847794/jobs/5305642876) from kubeflow-profiles-operator gives an example of this action working (CI is pinned to this PR's branch).  Previous to this PR, [the action would fail](https://github.com/canonical/kubeflow-profiles-operator/actions/runs/3236834548/jobs/5303166564).