### PR TITLE
fix: handle image names with repository in upload-charm

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21890,7 +21890,7 @@ exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
         // String docker.io/ from any image name, as they get removed in the `docker images` list
-        const imageName = uri.replace(/^docker.io/, '');
+        const imageName = uri.replace(/^docker.io\//, '');
         const result = yield (0, exec_1.getExecOutput)('docker', [
             'image',
             'ls',

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21863,30 +21863,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getImageDigest = exports.getImageName = void 0;
+exports.getImageDigest = void 0;
 const exec_1 = __nccwpck_require__(1514);
-/**
- * Returns a the image name given a container image URI, removing any leading repository info
- *
- * For uri's that contain slashes, the text before the first slash is inspected and discarded
- * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
- * part of the image name.  This procedure is documented in a note here:
- * https://www.docker.com/blog/how-to-use-your-own-registry-2/
- *
- * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
- */
-function getImageName(uri) {
-    const uriParts = uri.split('/');
-    if (uriParts.length === 1) {
-        return uri;
-    }
-    if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
-        // First segment of the URI is a registry.  Remove it
-        return uriParts.slice(1).join('/');
-    }
-    return uri;
-}
-exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
         // String docker.io/ from any image name, as they get removed in the `docker images` list

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21889,7 +21889,8 @@ function getImageName(uri) {
 exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
-        const imageName = getImageName(uri);
+        // String docker.io/ from any image name, as they get removed in the `docker images` list
+        const imageName = uri.replace(/^docker.io/, '');
         const result = yield (0, exec_1.getExecOutput)('docker', [
             'image',
             'ls',

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -22081,7 +22081,8 @@ function getImageName(uri) {
 exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
-        const imageName = getImageName(uri);
+        // String docker.io/ from any image name, as they get removed in the `docker images` list
+        const imageName = uri.replace(/^docker.io/, '');
         const result = yield (0, exec_1.getExecOutput)('docker', [
             'image',
             'ls',

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -22055,30 +22055,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getImageDigest = exports.getImageName = void 0;
+exports.getImageDigest = void 0;
 const exec_1 = __nccwpck_require__(1514);
-/**
- * Returns a the image name given a container image URI, removing any leading repository info
- *
- * For uri's that contain slashes, the text before the first slash is inspected and discarded
- * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
- * part of the image name.  This procedure is documented in a note here:
- * https://www.docker.com/blog/how-to-use-your-own-registry-2/
- *
- * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
- */
-function getImageName(uri) {
-    const uriParts = uri.split('/');
-    if (uriParts.length === 1) {
-        return uri;
-    }
-    if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
-        // First segment of the URI is a registry.  Remove it
-        return uriParts.slice(1).join('/');
-    }
-    return uri;
-}
-exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
         // String docker.io/ from any image name, as they get removed in the `docker images` list

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -22082,7 +22082,7 @@ exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
         // String docker.io/ from any image name, as they get removed in the `docker images` list
-        const imageName = uri.replace(/^docker.io/, '');
+        const imageName = uri.replace(/^docker.io\//, '');
         const result = yield (0, exec_1.getExecOutput)('docker', [
             'image',
             'ls',

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21981,7 +21981,7 @@ exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
         // String docker.io/ from any image name, as they get removed in the `docker images` list
-        const imageName = uri.replace(/^docker.io/, '');
+        const imageName = uri.replace(/^docker.io\//, '');
         const result = yield (0, exec_1.getExecOutput)('docker', [
             'image',
             'ls',

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21954,30 +21954,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getImageDigest = exports.getImageName = void 0;
+exports.getImageDigest = void 0;
 const exec_1 = __nccwpck_require__(1514);
-/**
- * Returns a the image name given a container image URI, removing any leading repository info
- *
- * For uri's that contain slashes, the text before the first slash is inspected and discarded
- * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
- * part of the image name.  This procedure is documented in a note here:
- * https://www.docker.com/blog/how-to-use-your-own-registry-2/
- *
- * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
- */
-function getImageName(uri) {
-    const uriParts = uri.split('/');
-    if (uriParts.length === 1) {
-        return uri;
-    }
-    if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
-        // First segment of the URI is a registry.  Remove it
-        return uriParts.slice(1).join('/');
-    }
-    return uri;
-}
-exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
         // String docker.io/ from any image name, as they get removed in the `docker images` list

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21980,7 +21980,8 @@ function getImageName(uri) {
 exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
-        const imageName = getImageName(uri);
+        // String docker.io/ from any image name, as they get removed in the `docker images` list
+        const imageName = uri.replace(/^docker.io/, '');
         const result = yield (0, exec_1.getExecOutput)('docker', [
             'image',
             'ls',

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21959,7 +21959,8 @@ function getImageName(uri) {
 exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
-        const imageName = getImageName(uri);
+        // String docker.io/ from any image name, as they get removed in the `docker images` list
+        const imageName = uri.replace(/^docker.io/, '');
         const result = yield (0, exec_1.getExecOutput)('docker', [
             'image',
             'ls',

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21960,7 +21960,7 @@ exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
         // String docker.io/ from any image name, as they get removed in the `docker images` list
-        const imageName = uri.replace(/^docker.io/, '');
+        const imageName = uri.replace(/^docker.io\//, '');
         const result = yield (0, exec_1.getExecOutput)('docker', [
             'image',
             'ls',

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21933,30 +21933,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getImageDigest = exports.getImageName = void 0;
+exports.getImageDigest = void 0;
 const exec_1 = __nccwpck_require__(1514);
-/**
- * Returns a the image name given a container image URI, removing any leading repository info
- *
- * For uri's that contain slashes, the text before the first slash is inspected and discarded
- * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
- * part of the image name.  This procedure is documented in a note here:
- * https://www.docker.com/blog/how-to-use-your-own-registry-2/
- *
- * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
- */
-function getImageName(uri) {
-    const uriParts = uri.split('/');
-    if (uriParts.length === 1) {
-        return uri;
-    }
-    if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
-        // First segment of the URI is a registry.  Remove it
-        return uriParts.slice(1).join('/');
-    }
-    return uri;
-}
-exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
         // String docker.io/ from any image name, as they get removed in the `docker images` list

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21960,30 +21960,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getImageDigest = exports.getImageName = void 0;
+exports.getImageDigest = void 0;
 const exec_1 = __nccwpck_require__(1514);
-/**
- * Returns a the image name given a container image URI, removing any leading repository info
- *
- * For uri's that contain slashes, the text before the first slash is inspected and discarded
- * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
- * part of the image name.  This procedure is documented in a note here:
- * https://www.docker.com/blog/how-to-use-your-own-registry-2/
- *
- * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
- */
-function getImageName(uri) {
-    const uriParts = uri.split('/');
-    if (uriParts.length === 1) {
-        return uri;
-    }
-    if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
-        // First segment of the URI is a registry.  Remove it
-        return uriParts.slice(1).join('/');
-    }
-    return uri;
-}
-exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
         // String docker.io/ from any image name, as they get removed in the `docker images` list

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21987,7 +21987,7 @@ exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
         // String docker.io/ from any image name, as they get removed in the `docker images` list
-        const imageName = uri.replace(/^docker.io/, '');
+        const imageName = uri.replace(/^docker.io\//, '');
         const result = yield (0, exec_1.getExecOutput)('docker', [
             'image',
             'ls',

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21986,7 +21986,8 @@ function getImageName(uri) {
 exports.getImageName = getImageName;
 function getImageDigest(uri) {
     return __awaiter(this, void 0, void 0, function* () {
-        const imageName = getImageName(uri);
+        // String docker.io/ from any image name, as they get removed in the `docker images` list
+        const imageName = uri.replace(/^docker.io/, '');
         const result = yield (0, exec_1.getExecOutput)('docker', [
             'image',
             'ls',

--- a/src/services/docker/docker.test.ts
+++ b/src/services/docker/docker.test.ts
@@ -1,30 +1,7 @@
 import * as exec from '@actions/exec';
-import { getImageDigest, getImageName } from './docker';
+import { getImageDigest } from './docker';
 
 describe('the container image service', () => {
-  [
-    {
-      uri: 'username/imagename:tag',
-      expectedName: 'username/imagename:tag',
-    },
-    {
-      uri: 'repo.url/username/imagename:tag',
-      expectedName: 'username/imagename:tag',
-    },
-    {
-      uri: 'localhost:port/username/imagename:tag',
-      expectedName: 'username/imagename:tag',
-    },
-    {
-      uri: 'imagename:tag',
-      expectedName: 'imagename:tag',
-    },
-  ].forEach(({ uri, expectedName }) => {
-    it(`should return the correct image name`, () => {
-      expect(getImageName(uri)).toEqual(expectedName);
-    });
-  });
-
   it('should return a digest it available', async () => {
     const dockerReturn = `somedigest`;
 
@@ -72,28 +49,5 @@ describe('the container image service', () => {
     await expect(getImageDigest('placeholder-image')).rejects.toThrow(
       Error(expectedError)
     );
-  });
-
-  [
-    {
-      uri: 'username/imagename:tag',
-      expectedName: 'username/imagename:tag',
-    },
-    {
-      uri: 'repo.url/username/imagename:tag',
-      expectedName: 'username/imagename:tag',
-    },
-    {
-      uri: 'localhost:port/username/imagename:tag',
-      expectedName: 'username/imagename:tag',
-    },
-    {
-      uri: 'imagename:tag',
-      expectedName: 'imagename:tag',
-    },
-  ].forEach(({ uri, expectedName }) => {
-    it(`should return the correct image name`, () => {
-      expect(getImageName(uri)).toEqual(expectedName);
-    });
   });
 });

--- a/src/services/docker/docker.ts
+++ b/src/services/docker/docker.ts
@@ -1,27 +1,5 @@
 import { getExecOutput } from '@actions/exec';
 
-/**
- * Returns a the image name given a container image URI, removing any leading repository info
- *
- * For uri's that contain slashes, the text before the first slash is inspected and discarded
- * if contains any '.' or ':' characters, as these indicate it defines a registry and is not
- * part of the image name.  This procedure is documented in a note here:
- * https://www.docker.com/blog/how-to-use-your-own-registry-2/
- *
- * @param uri Container image URI, which may or may not include a leading repository.  For example, `some.repo:port/imageName:imageTag` or `someUser/imageName:imageTag`
- */
-export function getImageName(uri: string): string {
-  const uriParts = uri.split('/');
-  if (uriParts.length === 1) {
-    return uri;
-  }
-  if (uriParts[0].indexOf('.') > 0 || uriParts[0].indexOf(':') > 0) {
-    // First segment of the URI is a registry.  Remove it
-    return uriParts.slice(1).join('/');
-  }
-  return uri;
-}
-
 export async function getImageDigest(uri: string): Promise<string> {
   // String docker.io/ from any image name, as they get removed in the `docker images` list
   const imageName = uri.replace(/^docker.io\//, '');

--- a/src/services/docker/docker.ts
+++ b/src/services/docker/docker.ts
@@ -23,7 +23,8 @@ export function getImageName(uri: string): string {
 }
 
 export async function getImageDigest(uri: string): Promise<string> {
-  const imageName = getImageName(uri);
+  // String docker.io/ from any image name, as they get removed in the `docker images` list
+  const imageName = uri.replace(/^docker.io/, '');
 
   const result = await getExecOutput('docker', [
     'image',

--- a/src/services/docker/docker.ts
+++ b/src/services/docker/docker.ts
@@ -24,7 +24,7 @@ export function getImageName(uri: string): string {
 
 export async function getImageDigest(uri: string): Promise<string> {
   // String docker.io/ from any image name, as they get removed in the `docker images` list
-  const imageName = uri.replace(/^docker.io/, '');
+  const imageName = uri.replace(/^docker.io\//, '');
 
   const result = await getExecOutput('docker', [
     'image',


### PR DESCRIPTION
`docker image ls imagename` expects `imagename` to exclude the repository
if it is from `docker.io/`, but include the repository otherwise.
Previously, `getImageDigest` incorrectly always stripped the repository
from the imagename.

For example:

```
docker pull docker.io/alpine:latest
docker image ls alpine
```

will show images with Repository=alpine, NOT docker.io/alpine, and

```
docker image ls docker.io/alpine
```

returns an empty list.  But,

```
docker pull quay.io/helix-ml/mlflow
docker image ls helix-ml/mlflow
docker image ls mlflow
```

returns empty lists, while

```
docker image ls quay.io/helix-ml/mlflow
```

returns the expected image.
