### PR TITLE
fix(message): Replace where with were in warnings

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21560,7 +21560,7 @@ class Charmcraft {
         return __awaiter(this, void 0, void 0, function* () {
             let resourceInfo = 'resources:\n';
             if (!this.uploadImage) {
-                const msg = `No resources where uploaded as part of this build.\n` +
+                const msg = `No resources were uploaded as part of this build.\n` +
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21752,7 +21752,7 @@ class Charmcraft {
         return __awaiter(this, void 0, void 0, function* () {
             let resourceInfo = 'resources:\n';
             if (!this.uploadImage) {
-                const msg = `No resources where uploaded as part of this build.\n` +
+                const msg = `No resources were uploaded as part of this build.\n` +
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21651,7 +21651,7 @@ class Charmcraft {
         return __awaiter(this, void 0, void 0, function* () {
             let resourceInfo = 'resources:\n';
             if (!this.uploadImage) {
-                const msg = `No resources where uploaded as part of this build.\n` +
+                const msg = `No resources were uploaded as part of this build.\n` +
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21630,7 +21630,7 @@ class Charmcraft {
         return __awaiter(this, void 0, void 0, function* () {
             let resourceInfo = 'resources:\n';
             if (!this.uploadImage) {
-                const msg = `No resources where uploaded as part of this build.\n` +
+                const msg = `No resources were uploaded as part of this build.\n` +
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21657,7 +21657,7 @@ class Charmcraft {
         return __awaiter(this, void 0, void 0, function* () {
             let resourceInfo = 'resources:\n';
             if (!this.uploadImage) {
-                const msg = `No resources where uploaded as part of this build.\n` +
+                const msg = `No resources were uploaded as part of this build.\n` +
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }

--- a/dist/upload/index.js
+++ b/dist/upload/index.js
@@ -21630,7 +21630,7 @@ class Charmcraft {
         return __awaiter(this, void 0, void 0, function* () {
             let resourceInfo = 'resources:\n';
             if (!this.uploadImage) {
-                const msg = `No resources where uploaded as part of this build.\n` +
+                const msg = `No resources were uploaded as part of this build.\n` +
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
                 return { flags: [''], resourceInfo: '' };

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -30,7 +30,7 @@ class Charmcraft {
     let resourceInfo = 'resources:\n';
     if (!this.uploadImage) {
       const msg =
-        `No resources where uploaded as part of this build.\n` +
+        `No resources were uploaded as part of this build.\n` +
         `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
       core.warning(msg);
     }


### PR DESCRIPTION
When you use charming-actions, you can get a warning that reads `No resources where uploaded as part of this build` and it should be `were uploaded`. This PR fixes this.