### PR TITLE
Gather logs from sudo and non-sudo invocation of charmcraft

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21385,32 +21385,29 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Artifact = void 0;
 const artifact = __importStar(__nccwpck_require__(2605));
+const exec_1 = __nccwpck_require__(1514);
 const fs = __importStar(__nccwpck_require__(7147));
 const glob = __importStar(__nccwpck_require__(8090));
 class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
+            const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
             // We're running some charmcraft commands as sudo as others as a
             // regular user - we want to capture both.
-            const basePaths = [
-                '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
-                '/root/snap/charmcraft/common/cache/charmcraft/log/',
+            const args = [
+                'cp',
+                '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
+                basePath,
             ];
-            const msg = [];
-            basePaths.forEach((basePath) => __awaiter(this, void 0, void 0, function* () {
-                if (!fs.existsSync(basePath)) {
-                    msg.push(`No charmcraft logs found at ${basePath}, skipping artifact upload.`);
-                }
-                else {
-                    const globber = yield glob.create(`${basePath}/*.log`);
-                    const files = yield globber.glob();
-                    const artifacts = artifact.create();
-                    const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
-                    const result = yield artifacts.uploadArtifact(artifactName, files, basePath);
-                    msg.push(`Artifact ${artifactName} upload result: ${JSON.stringify(result)}`);
-                }
-            }));
-            return msg.join('\r\n');
+            yield (0, exec_1.exec)('sudo', args);
+            if (!fs.existsSync(basePath)) {
+                return 'No charmcraft logs generated, skipping artifact upload.';
+            }
+            const globber = yield glob.create(`${basePath}/*.log`);
+            const files = yield globber.glob();
+            const artifacts = artifact.create();
+            const result = yield artifacts.uploadArtifact('charmcraft-logs', files, basePath);
+            return `Artifact upload result: ${JSON.stringify(result)}`;
         });
     }
 }

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21392,14 +21392,19 @@ class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
             const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
+            const sudoPath = '/root/snap/charmcraft/common/cache/charmcraft/log';
             // We're running some charmcraft commands as sudo as others as a
             // regular user - we want to capture both.
-            const args = [
-                'cp',
-                '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
-                basePath,
-            ];
-            yield (0, exec_1.exec)('sudo', args);
+            // First check if the path created by sudo invocations of charmcraft
+            // exists.
+            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath]);
+            if (dirExistsExitCode === 0) {
+                // Make sure the directory we're copying to exists as well.
+                if (!fs.existsSync(basePath)) {
+                    yield (0, exec_1.exec)('mkdir', ['-p', basePath]);
+                }
+                yield (0, exec_1.exec)('sudo', ['cp', `${sudoPath}/.`, basePath]);
+            }
             if (!fs.existsSync(basePath)) {
                 return 'No charmcraft logs generated, skipping artifact upload.';
             }

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21397,13 +21397,15 @@ class Artifact {
             // regular user - we want to capture both.
             // First check if the path created by sudo invocations of charmcraft
             // exists.
-            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath]);
+            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath], {
+                ignoreReturnCode: true,
+            });
             if (dirExistsExitCode === 0) {
                 // Make sure the directory we're copying to exists as well.
                 if (!fs.existsSync(basePath)) {
                     yield (0, exec_1.exec)('mkdir', ['-p', basePath]);
                 }
-                yield (0, exec_1.exec)('sudo', ['cp', `${sudoPath}/.`, basePath]);
+                yield (0, exec_1.exec)('sudo', ['cp', '-r', `${sudoPath}/.`, basePath]);
             }
             if (!fs.existsSync(basePath)) {
                 return 'No charmcraft logs generated, skipping artifact upload.';

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -21390,15 +21390,27 @@ const glob = __importStar(__nccwpck_require__(8090));
 class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
-            const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
-            if (!fs.existsSync(basePath)) {
-                return 'No charmcraft logs generated, skipping artifact upload.';
-            }
-            const globber = yield glob.create(`${basePath}/*.log`);
-            const files = yield globber.glob();
-            const artifacts = artifact.create();
-            const result = yield artifacts.uploadArtifact('charmcraft-logs', files, basePath);
-            return `Artifact upload result: ${JSON.stringify(result)}`;
+            // We're running some charmcraft commands as sudo as others as a
+            // regular user - we want to capture both.
+            const basePaths = [
+                '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
+                '/root/snap/charmcraft/common/cache/charmcraft/log/',
+            ];
+            const msg = [];
+            basePaths.forEach((basePath) => __awaiter(this, void 0, void 0, function* () {
+                if (!fs.existsSync(basePath)) {
+                    msg.push(`No charmcraft logs found at ${basePath}, skipping artifact upload.`);
+                }
+                else {
+                    const globber = yield glob.create(`${basePath}/*.log`);
+                    const files = yield globber.glob();
+                    const artifacts = artifact.create();
+                    const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
+                    const result = yield artifacts.uploadArtifact(artifactName, files, basePath);
+                    msg.push(`Artifact ${artifactName} upload result: ${JSON.stringify(result)}`);
+                }
+            }));
+            return msg.join('\r\n');
         });
     }
 }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21589,13 +21589,15 @@ class Artifact {
             // regular user - we want to capture both.
             // First check if the path created by sudo invocations of charmcraft
             // exists.
-            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath]);
+            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath], {
+                ignoreReturnCode: true,
+            });
             if (dirExistsExitCode === 0) {
                 // Make sure the directory we're copying to exists as well.
                 if (!fs.existsSync(basePath)) {
                     yield (0, exec_1.exec)('mkdir', ['-p', basePath]);
                 }
-                yield (0, exec_1.exec)('sudo', ['cp', `${sudoPath}/.`, basePath]);
+                yield (0, exec_1.exec)('sudo', ['cp', '-r', `${sudoPath}/.`, basePath]);
             }
             if (!fs.existsSync(basePath)) {
                 return 'No charmcraft logs generated, skipping artifact upload.';

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21584,14 +21584,19 @@ class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
             const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
+            const sudoPath = '/root/snap/charmcraft/common/cache/charmcraft/log';
             // We're running some charmcraft commands as sudo as others as a
             // regular user - we want to capture both.
-            const args = [
-                'cp',
-                '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
-                basePath,
-            ];
-            yield (0, exec_1.exec)('sudo', args);
+            // First check if the path created by sudo invocations of charmcraft
+            // exists.
+            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath]);
+            if (dirExistsExitCode === 0) {
+                // Make sure the directory we're copying to exists as well.
+                if (!fs.existsSync(basePath)) {
+                    yield (0, exec_1.exec)('mkdir', ['-p', basePath]);
+                }
+                yield (0, exec_1.exec)('sudo', ['cp', `${sudoPath}/.`, basePath]);
+            }
             if (!fs.existsSync(basePath)) {
                 return 'No charmcraft logs generated, skipping artifact upload.';
             }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -21577,32 +21577,29 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Artifact = void 0;
 const artifact = __importStar(__nccwpck_require__(2605));
+const exec_1 = __nccwpck_require__(1514);
 const fs = __importStar(__nccwpck_require__(7147));
 const glob = __importStar(__nccwpck_require__(8090));
 class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
+            const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
             // We're running some charmcraft commands as sudo as others as a
             // regular user - we want to capture both.
-            const basePaths = [
-                '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
-                '/root/snap/charmcraft/common/cache/charmcraft/log/',
+            const args = [
+                'cp',
+                '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
+                basePath,
             ];
-            const msg = [];
-            basePaths.forEach((basePath) => __awaiter(this, void 0, void 0, function* () {
-                if (!fs.existsSync(basePath)) {
-                    msg.push(`No charmcraft logs found at ${basePath}, skipping artifact upload.`);
-                }
-                else {
-                    const globber = yield glob.create(`${basePath}/*.log`);
-                    const files = yield globber.glob();
-                    const artifacts = artifact.create();
-                    const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
-                    const result = yield artifacts.uploadArtifact(artifactName, files, basePath);
-                    msg.push(`Artifact ${artifactName} upload result: ${JSON.stringify(result)}`);
-                }
-            }));
-            return msg.join('\r\n');
+            yield (0, exec_1.exec)('sudo', args);
+            if (!fs.existsSync(basePath)) {
+                return 'No charmcraft logs generated, skipping artifact upload.';
+            }
+            const globber = yield glob.create(`${basePath}/*.log`);
+            const files = yield globber.glob();
+            const artifacts = artifact.create();
+            const result = yield artifacts.uploadArtifact('charmcraft-logs', files, basePath);
+            return `Artifact upload result: ${JSON.stringify(result)}`;
         });
     }
 }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21488,13 +21488,15 @@ class Artifact {
             // regular user - we want to capture both.
             // First check if the path created by sudo invocations of charmcraft
             // exists.
-            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath]);
+            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath], {
+                ignoreReturnCode: true,
+            });
             if (dirExistsExitCode === 0) {
                 // Make sure the directory we're copying to exists as well.
                 if (!fs.existsSync(basePath)) {
                     yield (0, exec_1.exec)('mkdir', ['-p', basePath]);
                 }
-                yield (0, exec_1.exec)('sudo', ['cp', `${sudoPath}/.`, basePath]);
+                yield (0, exec_1.exec)('sudo', ['cp', '-r', `${sudoPath}/.`, basePath]);
             }
             if (!fs.existsSync(basePath)) {
                 return 'No charmcraft logs generated, skipping artifact upload.';

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21481,15 +21481,27 @@ const glob = __importStar(__nccwpck_require__(8090));
 class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
-            const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
-            if (!fs.existsSync(basePath)) {
-                return 'No charmcraft logs generated, skipping artifact upload.';
-            }
-            const globber = yield glob.create(`${basePath}/*.log`);
-            const files = yield globber.glob();
-            const artifacts = artifact.create();
-            const result = yield artifacts.uploadArtifact('charmcraft-logs', files, basePath);
-            return `Artifact upload result: ${JSON.stringify(result)}`;
+            // We're running some charmcraft commands as sudo as others as a
+            // regular user - we want to capture both.
+            const basePaths = [
+                '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
+                '/root/snap/charmcraft/common/cache/charmcraft/log/',
+            ];
+            const msg = [];
+            basePaths.forEach((basePath) => __awaiter(this, void 0, void 0, function* () {
+                if (!fs.existsSync(basePath)) {
+                    msg.push(`No charmcraft logs found at ${basePath}, skipping artifact upload.`);
+                }
+                else {
+                    const globber = yield glob.create(`${basePath}/*.log`);
+                    const files = yield globber.glob();
+                    const artifacts = artifact.create();
+                    const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
+                    const result = yield artifacts.uploadArtifact(artifactName, files, basePath);
+                    msg.push(`Artifact ${artifactName} upload result: ${JSON.stringify(result)}`);
+                }
+            }));
+            return msg.join('\r\n');
         });
     }
 }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21476,32 +21476,29 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Artifact = void 0;
 const artifact = __importStar(__nccwpck_require__(2605));
+const exec_1 = __nccwpck_require__(1514);
 const fs = __importStar(__nccwpck_require__(7147));
 const glob = __importStar(__nccwpck_require__(8090));
 class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
+            const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
             // We're running some charmcraft commands as sudo as others as a
             // regular user - we want to capture both.
-            const basePaths = [
-                '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
-                '/root/snap/charmcraft/common/cache/charmcraft/log/',
+            const args = [
+                'cp',
+                '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
+                basePath,
             ];
-            const msg = [];
-            basePaths.forEach((basePath) => __awaiter(this, void 0, void 0, function* () {
-                if (!fs.existsSync(basePath)) {
-                    msg.push(`No charmcraft logs found at ${basePath}, skipping artifact upload.`);
-                }
-                else {
-                    const globber = yield glob.create(`${basePath}/*.log`);
-                    const files = yield globber.glob();
-                    const artifacts = artifact.create();
-                    const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
-                    const result = yield artifacts.uploadArtifact(artifactName, files, basePath);
-                    msg.push(`Artifact ${artifactName} upload result: ${JSON.stringify(result)}`);
-                }
-            }));
-            return msg.join('\r\n');
+            yield (0, exec_1.exec)('sudo', args);
+            if (!fs.existsSync(basePath)) {
+                return 'No charmcraft logs generated, skipping artifact upload.';
+            }
+            const globber = yield glob.create(`${basePath}/*.log`);
+            const files = yield globber.glob();
+            const artifacts = artifact.create();
+            const result = yield artifacts.uploadArtifact('charmcraft-logs', files, basePath);
+            return `Artifact upload result: ${JSON.stringify(result)}`;
         });
     }
 }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -21483,14 +21483,19 @@ class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
             const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
+            const sudoPath = '/root/snap/charmcraft/common/cache/charmcraft/log';
             // We're running some charmcraft commands as sudo as others as a
             // regular user - we want to capture both.
-            const args = [
-                'cp',
-                '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
-                basePath,
-            ];
-            yield (0, exec_1.exec)('sudo', args);
+            // First check if the path created by sudo invocations of charmcraft
+            // exists.
+            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath]);
+            if (dirExistsExitCode === 0) {
+                // Make sure the directory we're copying to exists as well.
+                if (!fs.existsSync(basePath)) {
+                    yield (0, exec_1.exec)('mkdir', ['-p', basePath]);
+                }
+                yield (0, exec_1.exec)('sudo', ['cp', `${sudoPath}/.`, basePath]);
+            }
             if (!fs.existsSync(basePath)) {
                 return 'No charmcraft logs generated, skipping artifact upload.';
             }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21455,32 +21455,29 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Artifact = void 0;
 const artifact = __importStar(__nccwpck_require__(2605));
+const exec_1 = __nccwpck_require__(1514);
 const fs = __importStar(__nccwpck_require__(7147));
 const glob = __importStar(__nccwpck_require__(8090));
 class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
+            const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
             // We're running some charmcraft commands as sudo as others as a
             // regular user - we want to capture both.
-            const basePaths = [
-                '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
-                '/root/snap/charmcraft/common/cache/charmcraft/log/',
+            const args = [
+                'cp',
+                '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
+                basePath,
             ];
-            const msg = [];
-            basePaths.forEach((basePath) => __awaiter(this, void 0, void 0, function* () {
-                if (!fs.existsSync(basePath)) {
-                    msg.push(`No charmcraft logs found at ${basePath}, skipping artifact upload.`);
-                }
-                else {
-                    const globber = yield glob.create(`${basePath}/*.log`);
-                    const files = yield globber.glob();
-                    const artifacts = artifact.create();
-                    const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
-                    const result = yield artifacts.uploadArtifact(artifactName, files, basePath);
-                    msg.push(`Artifact ${artifactName} upload result: ${JSON.stringify(result)}`);
-                }
-            }));
-            return msg.join('\r\n');
+            yield (0, exec_1.exec)('sudo', args);
+            if (!fs.existsSync(basePath)) {
+                return 'No charmcraft logs generated, skipping artifact upload.';
+            }
+            const globber = yield glob.create(`${basePath}/*.log`);
+            const files = yield globber.glob();
+            const artifacts = artifact.create();
+            const result = yield artifacts.uploadArtifact('charmcraft-logs', files, basePath);
+            return `Artifact upload result: ${JSON.stringify(result)}`;
         });
     }
 }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21462,14 +21462,19 @@ class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
             const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
+            const sudoPath = '/root/snap/charmcraft/common/cache/charmcraft/log';
             // We're running some charmcraft commands as sudo as others as a
             // regular user - we want to capture both.
-            const args = [
-                'cp',
-                '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
-                basePath,
-            ];
-            yield (0, exec_1.exec)('sudo', args);
+            // First check if the path created by sudo invocations of charmcraft
+            // exists.
+            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath]);
+            if (dirExistsExitCode === 0) {
+                // Make sure the directory we're copying to exists as well.
+                if (!fs.existsSync(basePath)) {
+                    yield (0, exec_1.exec)('mkdir', ['-p', basePath]);
+                }
+                yield (0, exec_1.exec)('sudo', ['cp', `${sudoPath}/.`, basePath]);
+            }
             if (!fs.existsSync(basePath)) {
                 return 'No charmcraft logs generated, skipping artifact upload.';
             }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21460,15 +21460,27 @@ const glob = __importStar(__nccwpck_require__(8090));
 class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
-            const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
-            if (!fs.existsSync(basePath)) {
-                return 'No charmcraft logs generated, skipping artifact upload.';
-            }
-            const globber = yield glob.create(`${basePath}/*.log`);
-            const files = yield globber.glob();
-            const artifacts = artifact.create();
-            const result = yield artifacts.uploadArtifact('charmcraft-logs', files, basePath);
-            return `Artifact upload result: ${JSON.stringify(result)}`;
+            // We're running some charmcraft commands as sudo as others as a
+            // regular user - we want to capture both.
+            const basePaths = [
+                '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
+                '/root/snap/charmcraft/common/cache/charmcraft/log/',
+            ];
+            const msg = [];
+            basePaths.forEach((basePath) => __awaiter(this, void 0, void 0, function* () {
+                if (!fs.existsSync(basePath)) {
+                    msg.push(`No charmcraft logs found at ${basePath}, skipping artifact upload.`);
+                }
+                else {
+                    const globber = yield glob.create(`${basePath}/*.log`);
+                    const files = yield globber.glob();
+                    const artifacts = artifact.create();
+                    const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
+                    const result = yield artifacts.uploadArtifact(artifactName, files, basePath);
+                    msg.push(`Artifact ${artifactName} upload result: ${JSON.stringify(result)}`);
+                }
+            }));
+            return msg.join('\r\n');
         });
     }
 }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -21467,13 +21467,15 @@ class Artifact {
             // regular user - we want to capture both.
             // First check if the path created by sudo invocations of charmcraft
             // exists.
-            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath]);
+            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath], {
+                ignoreReturnCode: true,
+            });
             if (dirExistsExitCode === 0) {
                 // Make sure the directory we're copying to exists as well.
                 if (!fs.existsSync(basePath)) {
                     yield (0, exec_1.exec)('mkdir', ['-p', basePath]);
                 }
-                yield (0, exec_1.exec)('sudo', ['cp', `${sudoPath}/.`, basePath]);
+                yield (0, exec_1.exec)('sudo', ['cp', '-r', `${sudoPath}/.`, basePath]);
             }
             if (!fs.existsSync(basePath)) {
                 return 'No charmcraft logs generated, skipping artifact upload.';

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21494,13 +21494,15 @@ class Artifact {
             // regular user - we want to capture both.
             // First check if the path created by sudo invocations of charmcraft
             // exists.
-            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath]);
+            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath], {
+                ignoreReturnCode: true,
+            });
             if (dirExistsExitCode === 0) {
                 // Make sure the directory we're copying to exists as well.
                 if (!fs.existsSync(basePath)) {
                     yield (0, exec_1.exec)('mkdir', ['-p', basePath]);
                 }
-                yield (0, exec_1.exec)('sudo', ['cp', `${sudoPath}/.`, basePath]);
+                yield (0, exec_1.exec)('sudo', ['cp', '-r', `${sudoPath}/.`, basePath]);
             }
             if (!fs.existsSync(basePath)) {
                 return 'No charmcraft logs generated, skipping artifact upload.';

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21482,32 +21482,29 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Artifact = void 0;
 const artifact = __importStar(__nccwpck_require__(2605));
+const exec_1 = __nccwpck_require__(1514);
 const fs = __importStar(__nccwpck_require__(7147));
 const glob = __importStar(__nccwpck_require__(8090));
 class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
+            const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
             // We're running some charmcraft commands as sudo as others as a
             // regular user - we want to capture both.
-            const basePaths = [
-                '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
-                '/root/snap/charmcraft/common/cache/charmcraft/log/',
+            const args = [
+                'cp',
+                '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
+                basePath,
             ];
-            const msg = [];
-            basePaths.forEach((basePath) => __awaiter(this, void 0, void 0, function* () {
-                if (!fs.existsSync(basePath)) {
-                    msg.push(`No charmcraft logs found at ${basePath}, skipping artifact upload.`);
-                }
-                else {
-                    const globber = yield glob.create(`${basePath}/*.log`);
-                    const files = yield globber.glob();
-                    const artifacts = artifact.create();
-                    const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
-                    const result = yield artifacts.uploadArtifact(artifactName, files, basePath);
-                    msg.push(`Artifact ${artifactName} upload result: ${JSON.stringify(result)}`);
-                }
-            }));
-            return msg.join('\r\n');
+            yield (0, exec_1.exec)('sudo', args);
+            if (!fs.existsSync(basePath)) {
+                return 'No charmcraft logs generated, skipping artifact upload.';
+            }
+            const globber = yield glob.create(`${basePath}/*.log`);
+            const files = yield globber.glob();
+            const artifacts = artifact.create();
+            const result = yield artifacts.uploadArtifact('charmcraft-logs', files, basePath);
+            return `Artifact upload result: ${JSON.stringify(result)}`;
         });
     }
 }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21487,15 +21487,27 @@ const glob = __importStar(__nccwpck_require__(8090));
 class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
-            const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
-            if (!fs.existsSync(basePath)) {
-                return 'No charmcraft logs generated, skipping artifact upload.';
-            }
-            const globber = yield glob.create(`${basePath}/*.log`);
-            const files = yield globber.glob();
-            const artifacts = artifact.create();
-            const result = yield artifacts.uploadArtifact('charmcraft-logs', files, basePath);
-            return `Artifact upload result: ${JSON.stringify(result)}`;
+            // We're running some charmcraft commands as sudo as others as a
+            // regular user - we want to capture both.
+            const basePaths = [
+                '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
+                '/root/snap/charmcraft/common/cache/charmcraft/log/',
+            ];
+            const msg = [];
+            basePaths.forEach((basePath) => __awaiter(this, void 0, void 0, function* () {
+                if (!fs.existsSync(basePath)) {
+                    msg.push(`No charmcraft logs found at ${basePath}, skipping artifact upload.`);
+                }
+                else {
+                    const globber = yield glob.create(`${basePath}/*.log`);
+                    const files = yield globber.glob();
+                    const artifacts = artifact.create();
+                    const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
+                    const result = yield artifacts.uploadArtifact(artifactName, files, basePath);
+                    msg.push(`Artifact ${artifactName} upload result: ${JSON.stringify(result)}`);
+                }
+            }));
+            return msg.join('\r\n');
         });
     }
 }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -21489,14 +21489,19 @@ class Artifact {
     uploadLogs() {
         return __awaiter(this, void 0, void 0, function* () {
             const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
+            const sudoPath = '/root/snap/charmcraft/common/cache/charmcraft/log';
             // We're running some charmcraft commands as sudo as others as a
             // regular user - we want to capture both.
-            const args = [
-                'cp',
-                '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
-                basePath,
-            ];
-            yield (0, exec_1.exec)('sudo', args);
+            // First check if the path created by sudo invocations of charmcraft
+            // exists.
+            const dirExistsExitCode = yield (0, exec_1.exec)('sudo', ['test', '-d', sudoPath]);
+            if (dirExistsExitCode === 0) {
+                // Make sure the directory we're copying to exists as well.
+                if (!fs.existsSync(basePath)) {
+                    yield (0, exec_1.exec)('mkdir', ['-p', basePath]);
+                }
+                yield (0, exec_1.exec)('sudo', ['cp', `${sudoPath}/.`, basePath]);
+            }
             if (!fs.existsSync(basePath)) {
                 return 'No charmcraft logs generated, skipping artifact upload.';
             }

--- a/src/services/artifact/artifact.ts
+++ b/src/services/artifact/artifact.ts
@@ -18,6 +18,7 @@ class Artifact {
     if (!fs.existsSync(basePath)) {
       return 'No charmcraft logs generated, skipping artifact upload.';
     }
+
     const globber = await glob.create(`${basePath}/*.log`);
     const files = await globber.glob();
     const artifacts = artifact.create();
@@ -27,6 +28,7 @@ class Artifact {
       files,
       basePath
     );
+
     return `Artifact upload result: ${JSON.stringify(result)}`;
   }
 }

--- a/src/services/artifact/artifact.ts
+++ b/src/services/artifact/artifact.ts
@@ -6,18 +6,22 @@ class Artifact {
   async uploadLogs() {
     // We're running some charmcraft commands as sudo as others as a
     // regular user - we want to capture both.
-    const basePaths = ['/home/runner/snap/charmcraft/common/cache/charmcraft/log', '/root/snap/charmcraft/common/cache/charmcraft/log/'];
-    var msg = [];
+    const basePaths: string[] = [
+      '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
+      '/root/snap/charmcraft/common/cache/charmcraft/log/',
+    ];
+    const msg: string[] = [];
 
-    basePaths.forEach(function(basePath){
-
+    basePaths.forEach(async (basePath) => {
       if (!fs.existsSync(basePath)) {
-        msg.push(`No charmcraft logs found at ${basePath}, skipping artifact upload.`);
+        msg.push(
+          `No charmcraft logs found at ${basePath}, skipping artifact upload.`
+        );
       } else {
         const globber = await glob.create(`${basePath}/*.log`);
         const files = await globber.glob();
         const artifacts = artifact.create();
-        const artifactName = 'charmcraft-logs-'+basePath.split('/')[1];
+        const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
 
         const result = await artifacts.uploadArtifact(
           artifactName,
@@ -25,7 +29,9 @@ class Artifact {
           basePath
         );
 
-        msg.push(`Artifact ${artifactName} upload result: ${JSON.stringify(result)}`);
+        msg.push(
+          `Artifact ${artifactName} upload result: ${JSON.stringify(result)}`
+        );
       }
     });
 

--- a/src/services/artifact/artifact.ts
+++ b/src/services/artifact/artifact.ts
@@ -12,13 +12,15 @@ class Artifact {
 
     // First check if the path created by sudo invocations of charmcraft
     // exists.
-    const dirExistsExitCode = await exec('sudo', ['test', '-d', sudoPath]);
+    const dirExistsExitCode = await exec('sudo', ['test', '-d', sudoPath], {
+      ignoreReturnCode: true,
+    });
     if (dirExistsExitCode === 0) {
       // Make sure the directory we're copying to exists as well.
       if (!fs.existsSync(basePath)) {
         await exec('mkdir', ['-p', basePath]);
       }
-      await exec('sudo', ['cp', `${sudoPath}/.`, basePath]);
+      await exec('sudo', ['cp', '-r', `${sudoPath}/.`, basePath]);
     }
 
     if (!fs.existsSync(basePath)) {

--- a/src/services/artifact/artifact.ts
+++ b/src/services/artifact/artifact.ts
@@ -1,41 +1,33 @@
 import * as artifact from '@actions/artifact';
+import { exec } from '@actions/exec';
 import * as fs from 'fs';
 import * as glob from '@actions/glob';
 
 class Artifact {
   async uploadLogs() {
+    const basePath = '/home/runner/snap/charmcraft/common/cache/charmcraft/log';
     // We're running some charmcraft commands as sudo as others as a
     // regular user - we want to capture both.
-    const basePaths: string[] = [
-      '/home/runner/snap/charmcraft/common/cache/charmcraft/log',
-      '/root/snap/charmcraft/common/cache/charmcraft/log/',
+    const args = [
+      'cp',
+      '/root/snap/charmcraft/common/cache/charmcraft/log/*log',
+      basePath,
     ];
-    const msg: string[] = [];
+    await exec('sudo', args);
 
-    basePaths.forEach(async (basePath) => {
-      if (!fs.existsSync(basePath)) {
-        msg.push(
-          `No charmcraft logs found at ${basePath}, skipping artifact upload.`
-        );
-      } else {
-        const globber = await glob.create(`${basePath}/*.log`);
-        const files = await globber.glob();
-        const artifacts = artifact.create();
-        const artifactName = `charmcraft-logs-${basePath.split('/')[1]}`;
+    if (!fs.existsSync(basePath)) {
+      return 'No charmcraft logs generated, skipping artifact upload.';
+    }
+    const globber = await glob.create(`${basePath}/*.log`);
+    const files = await globber.glob();
+    const artifacts = artifact.create();
 
-        const result = await artifacts.uploadArtifact(
-          artifactName,
-          files,
-          basePath
-        );
-
-        msg.push(
-          `Artifact ${artifactName} upload result: ${JSON.stringify(result)}`
-        );
-      }
-    });
-
-    return msg.join('\r\n');
+    const result = await artifacts.uploadArtifact(
+      'charmcraft-logs',
+      files,
+      basePath
+    );
+    return `Artifact upload result: ${JSON.stringify(result)}`;
   }
 }
 


### PR DESCRIPTION
In some cases we're running charmcraft commands with `sudo` and in others not, so make sure we're gathering logs in both cases. See https://github.com/canonical/nginx-ingress-integrator-operator/actions/runs/3445054467/jobs/5775634047 for an example of what this might miss.

This may need careful review of this as this is my first contribution to this project and I'm not very familiar with the tooling around npm.