### PR TITLE
add flag to disable destructive mode

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -22840,9 +22840,11 @@ class Charmcraft {
             name: metadata.name,
         };
     }
-    pack() {
+    pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--quiet'];
+            if (destructive)
+                args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -23033,9 +23033,11 @@ class Charmcraft {
             name: metadata.name,
         };
     }
-    pack() {
+    pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--quiet'];
+            if (destructive)
+                args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -22932,9 +22932,11 @@ class Charmcraft {
             name: metadata.name,
         };
     }
-    pack() {
+    pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--quiet'];
+            if (destructive)
+                args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -23063,9 +23063,11 @@ class Charmcraft {
             name: metadata.name,
         };
     }
-    pack() {
+    pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--quiet'];
+            if (destructive)
+                args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -22911,9 +22911,11 @@ class Charmcraft {
             name: metadata.name,
         };
     }
-    pack() {
+    pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--quiet'];
+            if (destructive)
+                args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -22526,6 +22526,7 @@ class UploadCharmAction {
         this.charmPath = core.getInput('charm-path');
         this.tagPrefix = core.getInput('tag-prefix');
         this.token = core.getInput('github-token');
+        this.destructive = core.getBooleanInput('destructive-mode');
         if (!this.token) {
             throw new Error(`Input 'github-token' is missing`);
         }
@@ -22548,7 +22549,7 @@ class UploadCharmAction {
             try {
                 yield this.snap.install('charmcraft', this.charmcraftChannel);
                 process.chdir(this.charmPath);
-                yield this.charmcraft.pack();
+                yield this.charmcraft.pack(this.destructive);
                 const overrides = this.overrides;
                 const imageResults = yield this.charmcraft.uploadResources(overrides);
                 const fileResults = yield this.charmcraft.fetchFileFlags(overrides);
@@ -22938,9 +22939,11 @@ class Charmcraft {
             name: metadata.name,
         };
     }
-    pack() {
+    pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
-            const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+            const args = ['charmcraft', 'pack', '--quiet'];
+            if (destructive)
+                args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
         });
     }

--- a/src/actions/upload-charm/upload-charm.ts
+++ b/src/actions/upload-charm/upload-charm.ts
@@ -10,6 +10,7 @@ export class UploadCharmAction {
   private charmcraft: Charmcraft;
 
   private channel: string;
+  private destructive: boolean;
   private charmcraftChannel: string;
   private charmPath: string;
   private tagPrefix?: string;
@@ -21,6 +22,7 @@ export class UploadCharmAction {
     this.charmPath = core.getInput('charm-path');
     this.tagPrefix = core.getInput('tag-prefix');
     this.token = core.getInput('github-token');
+    this.destructive = core.getBooleanInput('destructive-mode');
 
     if (!this.token) {
       throw new Error(`Input 'github-token' is missing`);
@@ -49,7 +51,7 @@ export class UploadCharmAction {
     try {
       await this.snap.install('charmcraft', this.charmcraftChannel);
       process.chdir(this.charmPath!);
-      await this.charmcraft.pack();
+      await this.charmcraft.pack(this.destructive);
       const overrides = this.overrides!;
 
       const imageResults = await this.charmcraft.uploadResources(overrides);

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -179,8 +179,11 @@ class Charmcraft {
     };
   }
 
-  async pack() {
-    const args = ['charmcraft', 'pack', '--destructive-mode', '--quiet'];
+  async pack(destructive?: boolean) {
+    const args = ['charmcraft', 'pack', '--quiet'];
+
+    if (destructive) args.push('--destructive-mode');
+
     await exec('sudo', args, this.execOptions);
   }
 

--- a/upload-charm/action.yaml
+++ b/upload-charm/action.yaml
@@ -2,6 +2,13 @@ name: Charmhub Upload
 description: Uploads a charm to charmhub.io
 author: Kenneth Koski
 inputs:
+  destructive-mode:
+    required: false
+    default: true
+    description: |
+      Can be used to turn off destructive mode while building.
+      This might be useful when building for other architectures than the one
+      of the runner.
   channel:
     required: false
     default: latest/edge


### PR DESCRIPTION
As requested by @taurus-forever and team. The default is, intentionally, to keep it enabled as that is what most users will likely want currently.

(No need to review the dist files as they are generated on push. 😅)

closes #80.