### PR TITLE
Fix destructive-mode option in README

### DIFF
--- a/upload-charm/README.md
+++ b/upload-charm/README.md
@@ -33,7 +33,7 @@ If you want to use a new resource, you'll have to cut a new resource revision **
 | `charm-path`         | Path to the charm we want to publish. Defaults to the current working directory.                                                                                         |          |
 | `channel`            | Channel on charmhub to publish the charm in. Defaults to `latest/edge`.                                                                                                  |          |
 | `credentials`        | Credentials [exported](https://juju.is/docs/sdk/remote-env-auth) using `charmcraft login --export`.                                                                      | ✔️       |
-| `destructive`        | Whether or not to pack using destructive mode. Defaults to `true`.                                                                                                        |         |
+| `destructive-mode`   | Whether or not to pack using destructive mode. Defaults to `true`.                                                                                                        |         |
 | `github-token`       | Github Token needed for automatic tagging when publishing                                                                                                                | ✔️       |
 | `tag-prefix`         | Tag prefix, useful when bundling multiple charms in the same repo using a matrix.                                                                                        |          |
 | `upload-image`       | Toggles whether image resources are uploaded to CharmHub or not. Defaults to `true`.                                                                                     |          |


### PR DESCRIPTION
Otherwise GH action doesn't work:

`Warning: Unexpected input(s) 'destructive', valid inputs are ['destructive-mode', 'channel', 'tag-prefix', 'charm-path', 'charmcraft-channel', 'upload-image', 'credentials', 'github-token', 'resource-overrides']`