### PR TITLE
build: use node16 for `check-libraries`

### DIFF
--- a/check-libraries/action.yaml
+++ b/check-libraries/action.yaml
@@ -8,7 +8,7 @@ branding:
   color: orange
 
 runs:
-  using: node12
+  using: node16
   main: ../dist/check-libraries/index.js
 
 inputs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "charmhub-upload-action",
-  "version": "0.2.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "charmhub-upload-action",
-      "version": "0.2.2",
+      "version": "2.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@actions/artifact": "^0.2.0",
-        "@actions/core": "^1.6.0",
+        "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.0",
         "@actions/github": "^5.0.0",
         "@actions/glob": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@actions/artifact": "^0.2.0",
-    "@actions/core": "^1.6.0",
+    "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.0",
     "@actions/github": "^5.0.0",
     "@actions/glob": "^0.2.0",


### PR DESCRIPTION
Currently, this action triggers a deprecation warning on every run. I'm naively changing this to test if it works!

Fixes #83 