### PR TITLE
update to node16 for deprecation warnings

### DIFF
--- a/channel/action.yaml
+++ b/channel/action.yaml
@@ -3,7 +3,7 @@ description: |
   Selects which channel a charm should be uploaded to based on git context
 author: Simon Aronsson
 runs:
-  using: node12
+  using: node16
   main: ../dist/channel/index.js
 branding:
   icon: upload-cloud

--- a/release-charm/action.yaml
+++ b/release-charm/action.yaml
@@ -51,7 +51,7 @@ inputs:
     description: |
       Github Token needed for updating Release Information
 runs:
-  using: node12
+  using: node16
   main: ../dist/release-charm/index.js
 branding:
   icon: upload-cloud

--- a/upload-bundle/action.yaml
+++ b/upload-bundle/action.yaml
@@ -32,7 +32,7 @@ inputs:
     description: |
       Github Token needed for automatic tagging when publishing
 runs:
-  using: node12
+  using: node16
   main: ../dist/upload-bundle/index.js
 branding:
   icon: upload-cloud

--- a/upload-charm/action.yaml
+++ b/upload-charm/action.yaml
@@ -51,7 +51,7 @@ inputs:
       
       Example: "promql-transform:2,prometheus-image:12"   
 runs:
-  using: node12
+  using: node16
   main: ../dist/upload-charm/index.js
 branding:
   icon: upload-cloud


### PR DESCRIPTION
GitHub mentions that Node.js 12 actions are deprecated; this PR updates the node version to fix the issue.

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: canonical/charming-actions/check-libraries@2.2.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```