### PR TITLE
Adds support for pre-built charms in the `upload-charm` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,11 @@ Finally, build the actions by running:
 ```
 $ npm run build
 ```
+
+### Tests
+
+Run unit tests:
+
+```
+$ npm test
+```

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -22846,21 +22846,22 @@ class Charmcraft {
             if (destructive)
                 args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
-        });
-    }
-    upload(channel, flags) {
-        return __awaiter(this, void 0, void 0, function* () {
             // as we don't know the name of the name of the charm file output, we'll need to glob for it.
             // however, we expect charmcraft pack to always output one charm file.
             const globber = yield glob.create('./*.charm');
             const paths = yield globber.glob();
+            return paths[0];
+        });
+    }
+    upload(charm, channel, flags) {
+        return __awaiter(this, void 0, void 0, function* () {
             const args = [
                 'upload',
                 '--format',
                 'json',
                 '--release',
                 channel,
-                paths[0],
+                charm,
                 ...flags,
             ];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -23039,21 +23039,22 @@ class Charmcraft {
             if (destructive)
                 args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
-        });
-    }
-    upload(channel, flags) {
-        return __awaiter(this, void 0, void 0, function* () {
             // as we don't know the name of the name of the charm file output, we'll need to glob for it.
             // however, we expect charmcraft pack to always output one charm file.
             const globber = yield glob.create('./*.charm');
             const paths = yield globber.glob();
+            return paths[0];
+        });
+    }
+    upload(charm, channel, flags) {
+        return __awaiter(this, void 0, void 0, function* () {
             const args = [
                 'upload',
                 '--format',
                 'json',
                 '--release',
                 channel,
-                paths[0],
+                charm,
                 ...flags,
             ];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -22938,21 +22938,22 @@ class Charmcraft {
             if (destructive)
                 args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
-        });
-    }
-    upload(channel, flags) {
-        return __awaiter(this, void 0, void 0, function* () {
             // as we don't know the name of the name of the charm file output, we'll need to glob for it.
             // however, we expect charmcraft pack to always output one charm file.
             const globber = yield glob.create('./*.charm');
             const paths = yield globber.glob();
+            return paths[0];
+        });
+    }
+    upload(charm, channel, flags) {
+        return __awaiter(this, void 0, void 0, function* () {
             const args = [
                 'upload',
                 '--format',
                 'json',
                 '--release',
                 channel,
-                paths[0],
+                charm,
                 ...flags,
             ];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -23069,21 +23069,22 @@ class Charmcraft {
             if (destructive)
                 args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
-        });
-    }
-    upload(channel, flags) {
-        return __awaiter(this, void 0, void 0, function* () {
             // as we don't know the name of the name of the charm file output, we'll need to glob for it.
             // however, we expect charmcraft pack to always output one charm file.
             const globber = yield glob.create('./*.charm');
             const paths = yield globber.glob();
+            return paths[0];
+        });
+    }
+    upload(charm, channel, flags) {
+        return __awaiter(this, void 0, void 0, function* () {
             const args = [
                 'upload',
                 '--format',
                 'json',
                 '--release',
                 channel,
-                paths[0],
+                charm,
                 ...flags,
             ];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -22917,21 +22917,22 @@ class Charmcraft {
             if (destructive)
                 args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
-        });
-    }
-    upload(channel, flags) {
-        return __awaiter(this, void 0, void 0, function* () {
             // as we don't know the name of the name of the charm file output, we'll need to glob for it.
             // however, we expect charmcraft pack to always output one charm file.
             const globber = yield glob.create('./*.charm');
             const paths = yield globber.glob();
+            return paths[0];
+        });
+    }
+    upload(charm, channel, flags) {
+        return __awaiter(this, void 0, void 0, function* () {
             const args = [
                 'upload',
                 '--format',
                 'json',
                 '--release',
                 channel,
-                paths[0],
+                charm,
                 ...flags,
             ];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);

--- a/src/actions/upload-charm/upload-charm.ts
+++ b/src/actions/upload-charm/upload-charm.ts
@@ -12,6 +12,7 @@ export class UploadCharmAction {
   private channel: string;
   private destructive: boolean;
   private charmcraftChannel: string;
+  private builtCharmPath: string;
   private charmPath: string;
   private tagPrefix?: string;
   private token: string;
@@ -19,6 +20,7 @@ export class UploadCharmAction {
   constructor() {
     this.channel = core.getInput('channel');
     this.charmcraftChannel = core.getInput('charmcraft-channel');
+    this.builtCharmPath = core.getInput('built-charm-path');
     this.charmPath = core.getInput('charm-path');
     this.tagPrefix = core.getInput('tag-prefix');
     this.token = core.getInput('github-token');
@@ -51,7 +53,11 @@ export class UploadCharmAction {
     try {
       await this.snap.install('charmcraft', this.charmcraftChannel);
       process.chdir(this.charmPath!);
-      await this.charmcraft.pack(this.destructive);
+
+      const charm = this.builtCharmPath
+        ? this.builtCharmPath
+        : await this.charmcraft.pack(this.destructive);
+
       const overrides = this.overrides!;
 
       const imageResults = await this.charmcraft.uploadResources(overrides);
@@ -70,7 +76,7 @@ export class UploadCharmAction {
         ...staticResults.flags,
       ];
 
-      const rev = await this.charmcraft.upload(this.channel, flags);
+      const rev = await this.charmcraft.upload(charm, this.channel, flags);
 
       await this.tagger.tag(rev, this.channel, resourceInfo, this.tagPrefix);
     } catch (error: any) {

--- a/src/services/charmcraft/charmcraft.test.ts
+++ b/src/services/charmcraft/charmcraft.test.ts
@@ -43,7 +43,9 @@ describe('the charmcraft service', () => {
           stdout: '{"revision": 2}',
         });
 
-        await charmcraft.upload('edge', ['--resource=resource_1:2']);
+        await charmcraft.upload('banana.charm', 'edge', [
+          '--resource=resource_1:2',
+        ]);
 
         expect(mockExec).toHaveBeenCalled();
         expect(mockExec).toHaveBeenCalledWith(
@@ -54,7 +56,7 @@ describe('the charmcraft service', () => {
             'json',
             '--release',
             'edge',
-            undefined,
+            'banana.charm',
             '--resource=resource_1:2',
           ],
           expect.anything()

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -185,21 +185,25 @@ class Charmcraft {
     if (destructive) args.push('--destructive-mode');
 
     await exec('sudo', args, this.execOptions);
-  }
-
-  async upload(channel: string, flags: string[]): Promise<string> {
     // as we don't know the name of the name of the charm file output, we'll need to glob for it.
     // however, we expect charmcraft pack to always output one charm file.
     const globber = await glob.create('./*.charm');
     const paths = await globber.glob();
+    return paths[0];
+  }
 
+  async upload(
+    charm: string,
+    channel: string,
+    flags: string[]
+  ): Promise<string> {
     const args = [
       'upload',
       '--format',
       'json',
       '--release',
       channel,
-      paths[0],
+      charm,
       ...flags,
     ];
     const result = await getExecOutput('charmcraft', args, this.execOptions);

--- a/upload-charm/README.md
+++ b/upload-charm/README.md
@@ -28,16 +28,17 @@ If you want to use a new resource, you'll have to cut a new resource revision **
 
 ### Inputs
 
-| Key                  | Description                                                                                                                                                              | Required |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
-| `charm-path`         | Path to the charm we want to publish. Defaults to the current working directory.                                                                                         |          |
-| `channel`            | Channel on charmhub to publish the charm in. Defaults to `latest/edge`.                                                                                                  |          |
-| `credentials`        | Credentials [exported](https://juju.is/docs/sdk/remote-env-auth) using `charmcraft login --export`.                                                                      | ✔️       |
-| `destructive-mode`   | Whether or not to pack using destructive mode. Defaults to `true`.                                                                                                        |         |
-| `github-token`       | Github Token needed for automatic tagging when publishing                                                                                                                | ✔️       |
-| `tag-prefix`         | Tag prefix, useful when bundling multiple charms in the same repo using a matrix.                                                                                        |          |
-| `upload-image`       | Toggles whether image resources are uploaded to CharmHub or not. Defaults to `true`.                                                                                     |          |
-| `charmcraft-channel` | Snap channel to use when installing charmcraft. Defaults to `latest/edge`.                                                                                               |          |
+| Key                  | Description                                                                                                      | Required |
+|----------------------|------------------------------------------------------------------------------------------------------------------| -------- |
+| `charm-path`         | Path to the charm we want to publish. Defaults to the current working directory.                                 |          |
+| `built-charm-path`   | Path to a pre-built charm we want to publish.                                                                    |          |
+| `channel`            | Channel on charmhub to publish the charm in. Defaults to `latest/edge`.                                          |          |
+| `credentials`        | Credentials [exported](https://juju.is/docs/sdk/remote-env-auth) using `charmcraft login --export`.              | ✔️       |
+| `destructive-mode`   | Whether or not to pack using destructive mode. Defaults to `true`.                                               |         |
+| `github-token`       | Github Token needed for automatic tagging when publishing                                                        | ✔️       |
+| `tag-prefix`         | Tag prefix, useful when bundling multiple charms in the same repo using a matrix.                                |          |
+| `upload-image`       | Toggles whether image resources are uploaded to CharmHub or not. Defaults to `true`.                             |          |
+| `charmcraft-channel` | Snap channel to use when installing charmcraft. Defaults to `latest/edge`.                                       |          |
 | `resource-overrides` | Charm resource revision overrides. Separate entries using commas, ie. `"promql-transform:2,prometheus-image:12"` |          |
 ### Outputs
 

--- a/upload-charm/action.yaml
+++ b/upload-charm/action.yaml
@@ -23,6 +23,10 @@ inputs:
     default: '.'
     description: |
       Path to charm directory
+  built-charm-path:
+    required: false
+    description: |
+      Path to a pre-built charm.
   charmcraft-channel:
     required: false
     default: 'latest/stable'


### PR DESCRIPTION
## Overview

This PR introduces the option to build a charm before passing it over to the `upload-charm` action. This is especially useful when one wants to test a charm before uploading it. The current state of the `upload-charm` action forces charm authors to re-build the charm after being tested, meaning that it's possible that the tested charm is not exactly the same as the one that was tested.

### Usage:

```yaml
name: Release

on:
  push:
    branches:
      - main

jobs:
  build:
    name: Release
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v3
      - name: Select charmhub channel
        uses: canonical/charming-actions/channel@2.2.6
        id: channel
      - name: Fetch Tested Charm
        uses: actions/download-artifact@v3
        with:
          name: tested-charm
      - name: Move charm in current directory
        run: find ./ -name my-precious.charm -exec mv -t ./ {} \;
      - name: Upload charm to charmhub
        uses: canonical/charming-actions/upload-charm@2.2.6
        with:
          built-charm-path: "my-precious.charm"
          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
          github-token: "${{ secrets.GITHUB_TOKEN }}"
          channel: "${{ steps.channel.outputs.name }}"
```

### Example executions
- [With the `built-charm-path` parameter](https://github.com/gruyaume/oai-5g-cu-operator/actions/runs/5026408407/jobs/9014908149#step:7:1)
- [Without the `built-charm-path` parameter](https://github.com/gruyaume/oai-5g-cu-operator/actions/runs/5026686072/jobs/9015277456#step:5:1)
