### PR TITLE
Add pull image option

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -22725,6 +22725,7 @@ const docker_1 = __nccwpck_require__(7585);
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
+        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -22785,9 +22786,11 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
-            if (pullExitCode !== 0) {
-                throw new Error('Could not pull the docker image.');
+            if (!this.localImage) {
+                const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
+                if (pullExitCode !== 0) {
+                    throw new Error('Could not pull the docker image.');
+                }
             }
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -22723,9 +22723,10 @@ const yaml = __importStar(__nccwpck_require__(1917));
 const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
-    constructor(token) {
+    constructor(token, pullImage) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
-        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
+        this.pullImage =
+            pullImage || core.getInput('pull-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -22786,7 +22787,7 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!this.localImage) {
+            if (this.pullImage) {
                 const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
                 if (pullExitCode !== 0) {
                     throw new Error('Could not pull the docker image.');

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -22918,6 +22918,7 @@ const docker_1 = __nccwpck_require__(7585);
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
+        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -22978,9 +22979,11 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
-            if (pullExitCode !== 0) {
-                throw new Error('Could not pull the docker image.');
+            if (!this.localImage) {
+                const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
+                if (pullExitCode !== 0) {
+                    throw new Error('Could not pull the docker image.');
+                }
             }
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -22916,9 +22916,10 @@ const yaml = __importStar(__nccwpck_require__(1917));
 const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
-    constructor(token) {
+    constructor(token, pullImage) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
-        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
+        this.pullImage =
+            pullImage || core.getInput('pull-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -22979,7 +22980,7 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!this.localImage) {
+            if (this.pullImage) {
                 const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
                 if (pullExitCode !== 0) {
                     throw new Error('Could not pull the docker image.');

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -22817,6 +22817,7 @@ const docker_1 = __nccwpck_require__(7585);
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
+        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -22877,9 +22878,11 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
-            if (pullExitCode !== 0) {
-                throw new Error('Could not pull the docker image.');
+            if (!this.localImage) {
+                const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
+                if (pullExitCode !== 0) {
+                    throw new Error('Could not pull the docker image.');
+                }
             }
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -22815,9 +22815,10 @@ const yaml = __importStar(__nccwpck_require__(1917));
 const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
-    constructor(token) {
+    constructor(token, pullImage) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
-        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
+        this.pullImage =
+            pullImage || core.getInput('pull-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -22878,7 +22879,7 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!this.localImage) {
+            if (this.pullImage) {
                 const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
                 if (pullExitCode !== 0) {
                     throw new Error('Could not pull the docker image.');

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -22946,9 +22946,10 @@ const yaml = __importStar(__nccwpck_require__(1917));
 const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
-    constructor(token) {
+    constructor(token, pullImage) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
-        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
+        this.pullImage =
+            pullImage || core.getInput('pull-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -23009,7 +23010,7 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!this.localImage) {
+            if (this.pullImage) {
                 const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
                 if (pullExitCode !== 0) {
                     throw new Error('Could not pull the docker image.');

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -22948,6 +22948,7 @@ const docker_1 = __nccwpck_require__(7585);
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
+        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -23008,9 +23009,11 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
-            if (pullExitCode !== 0) {
-                throw new Error('Could not pull the docker image.');
+            if (!this.localImage) {
+                const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
+                if (pullExitCode !== 0) {
+                    throw new Error('Could not pull the docker image.');
+                }
             }
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -22794,9 +22794,10 @@ const yaml = __importStar(__nccwpck_require__(1917));
 const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
-    constructor(token) {
+    constructor(token, pullImage) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
-        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
+        this.pullImage =
+            pullImage || core.getInput('pull-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -22857,7 +22858,7 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!this.localImage) {
+            if (this.pullImage) {
                 const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
                 if (pullExitCode !== 0) {
                     throw new Error('Could not pull the docker image.');

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -22796,6 +22796,7 @@ const docker_1 = __nccwpck_require__(7585);
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
+        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -22856,9 +22857,11 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
-            if (pullExitCode !== 0) {
-                throw new Error('Could not pull the docker image.');
+            if (!this.localImage) {
+                const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
+                if (pullExitCode !== 0) {
+                    throw new Error('Could not pull the docker image.');
+                }
             }
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -22827,6 +22827,7 @@ const docker_1 = __nccwpck_require__(7585);
 class Charmcraft {
     constructor(token) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
+        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -22887,9 +22888,11 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
-            if (pullExitCode !== 0) {
-                throw new Error('Could not pull the docker image.');
+            if (!this.localImage) {
+                const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
+                if (pullExitCode !== 0) {
+                    throw new Error('Could not pull the docker image.');
+                }
             }
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -22825,9 +22825,10 @@ const yaml = __importStar(__nccwpck_require__(1917));
 const docker_1 = __nccwpck_require__(7585);
 /* eslint-disable camelcase */
 class Charmcraft {
-    constructor(token) {
+    constructor(token, pullImage) {
         this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
-        this.localImage = core.getInput('local-image').toLowerCase() === 'true';
+        this.pullImage =
+            pullImage || core.getInput('pull-image').toLowerCase() === 'true';
         this.token = token || core.getInput('credentials');
         this.execOptions = {
             env: Object.assign(Object.assign({}, process.env), { CHARMCRAFT_AUTH: this.token }),
@@ -22888,7 +22889,7 @@ class Charmcraft {
     }
     uploadResource(resource_image, name, resource_name) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!this.localImage) {
+            if (this.pullImage) {
                 const pullExitCode = yield (0, exec_1.exec)('docker', ['pull', resource_image], this.execOptions);
                 if (pullExitCode !== 0) {
                     throw new Error('Could not pull the docker image.');

--- a/src/services/charmcraft/charmcraft.test.ts
+++ b/src/services/charmcraft/charmcraft.test.ts
@@ -98,7 +98,7 @@ describe('the charmcraft service', () => {
       describe('pulling images', () => {
         it('should succeed when image digest is available', async () => {
           const digest = `somedigest`;
-          const charmcraft = new Charmcraft('token');
+          const charmcraft = new Charmcraft('token', true);
 
           const mockedExec = jest.spyOn(exec, 'exec').mockResolvedValue(0);
 

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -13,13 +13,14 @@ import { Base, Mapping, Status, Track } from './types';
 
 class Charmcraft {
   private uploadImage: boolean;
-  private localImage: boolean;
+  private pullImage: boolean;
   private token: string;
   private execOptions: ExecOptions;
 
-  constructor(token?: string) {
+  constructor(token?: string, pullImage?: boolean) {
     this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
-    this.localImage = core.getInput('local-image').toLowerCase() === 'true';
+    this.pullImage =
+      pullImage || core.getInput('pull-image').toLowerCase() === 'true';
     this.token = token || core.getInput('credentials');
     this.execOptions = {
       env: {
@@ -110,7 +111,7 @@ class Charmcraft {
     name: string,
     resource_name: string
   ) {
-    if (!this.localImage) {
+    if (this.pullImage) {
       const pullExitCode = await exec(
         'docker',
         ['pull', resource_image],

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -13,11 +13,13 @@ import { Base, Mapping, Status, Track } from './types';
 
 class Charmcraft {
   private uploadImage: boolean;
+  private localImage: boolean;
   private token: string;
   private execOptions: ExecOptions;
 
   constructor(token?: string) {
     this.uploadImage = core.getInput('upload-image').toLowerCase() === 'true';
+    this.localImage = core.getInput('local-image').toLowerCase() === 'true';
     this.token = token || core.getInput('credentials');
     this.execOptions = {
       env: {
@@ -108,13 +110,15 @@ class Charmcraft {
     name: string,
     resource_name: string
   ) {
-    const pullExitCode = await exec(
-      'docker',
-      ['pull', resource_image],
-      this.execOptions
-    );
-    if (pullExitCode !== 0) {
-      throw new Error('Could not pull the docker image.');
+    if (!this.localImage) {
+      const pullExitCode = await exec(
+        'docker',
+        ['pull', resource_image],
+        this.execOptions
+      );
+      if (pullExitCode !== 0) {
+        throw new Error('Could not pull the docker image.');
+      }
     }
 
     const resourceDigest = await getImageDigest(resource_image);

--- a/upload-charm/README.md
+++ b/upload-charm/README.md
@@ -38,7 +38,7 @@ If you want to use a new resource, you'll have to cut a new resource revision **
 | `github-token`       | Github Token needed for automatic tagging when publishing                                                        | ✔️        |
 | `tag-prefix`         | Tag prefix, useful when bundling multiple charms in the same repo using a matrix.                                |          |
 | `upload-image`       | Toggles whether image resources are uploaded to CharmHub or not. Defaults to `true`.                             |          |
-| `local-image`        | Toggles whether image resources are pulled locally or from an upstream source. Defaults to `false`.              |          |
+| `pull-image`         | Toggles whether image resources are pulled. Defaults to `true`.                                                  |          |
 | `charmcraft-channel` | Snap channel to use when installing charmcraft. Defaults to `latest/edge`.                                       |          |
 | `resource-overrides` | Charm resource revision overrides. Separate entries using commas, ie. `"promql-transform:2,prometheus-image:12"` |          |
 ### Outputs

--- a/upload-charm/README.md
+++ b/upload-charm/README.md
@@ -33,11 +33,12 @@ If you want to use a new resource, you'll have to cut a new resource revision **
 | `charm-path`         | Path to the charm we want to publish. Defaults to the current working directory.                                 |          |
 | `built-charm-path`   | Path to a pre-built charm we want to publish.                                                                    |          |
 | `channel`            | Channel on charmhub to publish the charm in. Defaults to `latest/edge`.                                          |          |
-| `credentials`        | Credentials [exported](https://juju.is/docs/sdk/remote-env-auth) using `charmcraft login --export`.              | ✔️       |
-| `destructive-mode`   | Whether or not to pack using destructive mode. Defaults to `true`.                                               |         |
-| `github-token`       | Github Token needed for automatic tagging when publishing                                                        | ✔️       |
+| `credentials`        | Credentials [exported](https://juju.is/docs/sdk/remote-env-auth) using `charmcraft login --export`.              | ✔️        |
+| `destructive-mode`   | Whether or not to pack using destructive mode. Defaults to `true`.                                               |          |
+| `github-token`       | Github Token needed for automatic tagging when publishing                                                        | ✔️        |
 | `tag-prefix`         | Tag prefix, useful when bundling multiple charms in the same repo using a matrix.                                |          |
 | `upload-image`       | Toggles whether image resources are uploaded to CharmHub or not. Defaults to `true`.                             |          |
+| `local-image`        | Toggles whether image resources are pulled locally or from an upstream source. Defaults to `false`.              |          |
 | `charmcraft-channel` | Snap channel to use when installing charmcraft. Defaults to `latest/edge`.                                       |          |
 | `resource-overrides` | Charm resource revision overrides. Separate entries using commas, ie. `"promql-transform:2,prometheus-image:12"` |          |
 ### Outputs

--- a/upload-charm/action.yaml
+++ b/upload-charm/action.yaml
@@ -37,13 +37,14 @@ inputs:
     default: 'true'
     description: |
       Set to false if you don't want to update the OCI image
-  local-image:
+  pull-image:
     required: false
-    default: 'false'
+    default: 'true'
     description: |
-      Set to true if you want to use local OCI images. They must
-      be built prior to running the action. Set the upstream-resource
-      key in metadata.yaml to the name of the local image.
+      Set to false if you want to skip pulling OCI images. If false,
+      the OCI images must be present in the local docker registry prior
+      to running the action. Set the upstream-source key in metadata.yaml
+      to the name of the local image.
   credentials:
     required: true
     description: |

--- a/upload-charm/action.yaml
+++ b/upload-charm/action.yaml
@@ -37,6 +37,13 @@ inputs:
     default: 'true'
     description: |
       Set to false if you don't want to update the OCI image
+  local-image:
+    required: false
+    default: 'false'
+    description: |
+      Set to true if you want to use local OCI images. They must
+      be built prior to running the action. Set the upstream-resource
+      key in metadata.yaml to the name of the local image.
   credentials:
     required: true
     description: |


### PR DESCRIPTION
As described in #98 

This PR aims to address a limitation of the upload-charm action, where it enforces a charm's OCI image to come from an external source.

Some projects include a charm folder within their project essentially keeping the application and the charm together. In order to use this action, such projects would need to first upload their image to a container registry and then use the provided action to pull from that registry.

The following change adds a config option called pull-image that, when set to false, will skip the docker pull step when uploading charm resources. This is useful in cases where the image is already present locally. An example of these changes in use can be seen [here](https://github.com/canonical/pga/actions/runs/5112992089/workflow). If the config is set to false, it requires that the user build or obtain the OCI images before running the action, this has been explained in the Readme.