### PR TITLE
ci: run npm build during CI to ensure no failures

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -40,3 +40,17 @@ jobs:
         run: |
           npm run format
           npm run lint
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: |
+          npm install
+      - name: Build
+        run: |
+          npm run build

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,4 +1,4 @@
-name: Test Charmhub Upload
+name: CI
 
 on:
   push:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -54,3 +54,10 @@ jobs:
       - name: Build
         run: |
           npm run build
+
+          if [[ -n "$(git status -s)" ]]; then
+            echo "Please run 'npm run build' then commit/push changes"
+            echo
+            git diff
+            exit 1
+          fi

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
         with:
-          node-version: 16
+          node-version: 20
       - name: Install dependencies
         run: |
           npm install
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
         with:
-          node-version: 16
+          node-version: 20
       - name: Install dependencies
         run: |
           npm install

--- a/channel/action.yaml
+++ b/channel/action.yaml
@@ -3,7 +3,7 @@ description: |
   Selects which channel a charm should be uploaded to based on git context
 author: Simon Aronsson
 runs:
-  using: node16
+  using: node20
   main: ../dist/channel/index.js
 branding:
   icon: upload-cloud

--- a/check-libraries/action.yaml
+++ b/check-libraries/action.yaml
@@ -8,7 +8,7 @@ branding:
   color: orange
 
 runs:
-  using: node16
+  using: node20
   main: ../dist/check-libraries/index.js
 
 inputs:

--- a/release-charm/action.yaml
+++ b/release-charm/action.yaml
@@ -51,7 +51,7 @@ inputs:
     description: |
       Github Token needed for updating Release Information
 runs:
-  using: node16
+  using: node20
   main: ../dist/release-charm/index.js
 branding:
   icon: upload-cloud

--- a/release-libraries/action.yaml
+++ b/release-libraries/action.yaml
@@ -22,7 +22,7 @@ inputs:
     description: |
       Github Token needed for automatic tagging when publishing
 runs:
-  using: node16
+  using: node20
   main: ../dist/release-libraries/index.js
 branding:
   icon: upload-cloud

--- a/upload-bundle/action.yaml
+++ b/upload-bundle/action.yaml
@@ -32,7 +32,7 @@ inputs:
     description: |
       Github Token needed for automatic tagging when publishing
 runs:
-  using: node16
+  using: node20
   main: ../dist/upload-bundle/index.js
 branding:
   icon: upload-cloud

--- a/upload-charm/action.yaml
+++ b/upload-charm/action.yaml
@@ -63,7 +63,7 @@ inputs:
       
       Example: "promql-transform:2,prometheus-image:12"   
 runs:
-  using: node16
+  using: node20
   main: ../dist/upload-charm/index.js
 branding:
   icon: upload-cloud


### PR DESCRIPTION
This PR does two things:

- Bumps nodejs to the latest major LTS version (20)
- Adds a test to ensure that the build process succeeds