### PR TITLE
Support uploading multiple charm files

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42642,11 +42642,11 @@ class Charmcraft {
             if (destructive)
                 args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
-            // as we don't know the name of the name of the charm file output, we'll need to glob for it.
-            // however, we expect charmcraft pack to always output one charm file.
+            // As we don't know the name of the charm files output, we'll need to glob for them.
+            // As charmcraft pack could create multiple charm files, we return an array.
             const globber = yield glob.create('./*.charm');
             const paths = yield globber.glob();
-            return paths[0];
+            return paths;
         });
     }
     upload(charm, channel, flags) {

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -42837,11 +42837,11 @@ class Charmcraft {
             if (destructive)
                 args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
-            // as we don't know the name of the name of the charm file output, we'll need to glob for it.
-            // however, we expect charmcraft pack to always output one charm file.
+            // As we don't know the name of the charm files output, we'll need to glob for them.
+            // As charmcraft pack could create multiple charm files, we return an array.
             const globber = yield glob.create('./*.charm');
             const paths = yield globber.glob();
-            return paths[0];
+            return paths;
         });
     }
     upload(charm, channel, flags) {

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42733,11 +42733,11 @@ class Charmcraft {
             if (destructive)
                 args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
-            // as we don't know the name of the name of the charm file output, we'll need to glob for it.
-            // however, we expect charmcraft pack to always output one charm file.
+            // As we don't know the name of the charm files output, we'll need to glob for them.
+            // As charmcraft pack could create multiple charm files, we return an array.
             const globber = yield glob.create('./*.charm');
             const paths = yield globber.glob();
-            return paths[0];
+            return paths;
         });
     }
     upload(charm, channel, flags) {

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -42864,11 +42864,11 @@ class Charmcraft {
             if (destructive)
                 args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
-            // as we don't know the name of the name of the charm file output, we'll need to glob for it.
-            // however, we expect charmcraft pack to always output one charm file.
+            // As we don't know the name of the charm files output, we'll need to glob for them.
+            // As charmcraft pack could create multiple charm files, we return an array.
             const globber = yield glob.create('./*.charm');
             const paths = yield globber.glob();
-            return paths[0];
+            return paths;
         });
     }
     upload(charm, channel, flags) {

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42712,11 +42712,11 @@ class Charmcraft {
             if (destructive)
                 args.push('--destructive-mode');
             yield (0, exec_1.exec)('sudo', args, this.execOptions);
-            // as we don't know the name of the name of the charm file output, we'll need to glob for it.
-            // however, we expect charmcraft pack to always output one charm file.
+            // As we don't know the name of the charm files output, we'll need to glob for them.
+            // As charmcraft pack could create multiple charm files, we return an array.
             const globber = yield glob.create('./*.charm');
             const paths = yield globber.glob();
-            return paths[0];
+            return paths;
         });
     }
     upload(charm, channel, flags) {

--- a/src/actions/upload-charm/upload-charm.test.ts
+++ b/src/actions/upload-charm/upload-charm.test.ts
@@ -1,0 +1,68 @@
+import * as core from '@actions/core';
+import { UploadCharmAction } from './upload-charm';
+
+describe('the upload charm action', () => {
+  beforeEach(() => {
+    jest.spyOn(process, 'chdir').mockImplementation(() => {});
+    jest.spyOn(core, 'info').mockImplementation(() => {});
+    jest.spyOn(core, 'getBooleanInput').mockReturnValue(true);
+  });
+
+  [
+    { charmcraftPackOutput: ['/path/to/charm.charm'], builtCharmPath: '' }, // charmcraft pack produces one file
+    {
+      charmcraftPackOutput: ['/path/to/charm1.charm', '/path/to/charm2.charm'],
+      builtCharmPath: '',
+    }, // charmcraft pack produces two files
+    { charmcraftPackOutput: [], builtCharmPath: '/path/to/prebuilt.charm' }, // built-charm-path input option is provided
+  ].forEach(({ charmcraftPackOutput, builtCharmPath }) => {
+    it('should call charmcraft upload correct number of times with correct parameters', async () => {
+      jest.spyOn(core, 'getInput').mockImplementation((inputOption) => {
+        if (inputOption === 'built-charm-path') return builtCharmPath;
+        return 'something';
+      });
+
+      const action = new UploadCharmAction() as any;
+      action.snap.install = jest.fn();
+      action.charmcraft.uploadResources = jest.fn(() => ({
+        flags: ['f1', 'f2'],
+        resourceInfo: 'some info',
+      }));
+      action.charmcraft.fetchFileFlags = jest.fn(() => ({
+        flags: ['f1', 'f2'],
+        resourceInfo: 'some info',
+      }));
+      action.charmcraft.buildStaticFlags = jest.fn(() => ({
+        flags: ['f1', 'f2'],
+        resourceInfo: 'some info',
+      }));
+      action.charmcraft.upload = jest.fn();
+      action.tagger.tag = jest.fn();
+      action.artifacts.uploadLogs = jest.fn();
+
+      action.charmcraft.pack = jest.fn(() => charmcraftPackOutput);
+
+      await action.run();
+
+      if (builtCharmPath) {
+        expect(action.charmcraft.upload).toHaveBeenCalledTimes(1);
+        expect(action.charmcraft.upload).toHaveBeenCalledWith(
+          builtCharmPath,
+          'something',
+          ['f1', 'f2', 'f1', 'f2', 'f1', 'f2'],
+        );
+      } else {
+        expect(action.charmcraft.upload).toHaveBeenCalledTimes(
+          charmcraftPackOutput.length,
+        );
+        charmcraftPackOutput.forEach((charmFile) => {
+          expect(action.charmcraft.upload).toHaveBeenCalledWith(
+            charmFile,
+            'something',
+            ['f1', 'f2', 'f1', 'f2', 'f1', 'f2'],
+          );
+        });
+      }
+    });
+  });
+});

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -190,11 +190,11 @@ class Charmcraft {
     if (destructive) args.push('--destructive-mode');
 
     await exec('sudo', args, this.execOptions);
-    // as we don't know the name of the name of the charm file output, we'll need to glob for it.
-    // however, we expect charmcraft pack to always output one charm file.
+    // As we don't know the name of the charm files output, we'll need to glob for them.
+    // As charmcraft pack could create multiple charm files, we return an array.
     const globber = await glob.create('./*.charm');
     const paths = await globber.glob();
-    return paths[0];
+    return paths;
   }
 
   async upload(


### PR DESCRIPTION
In cases where `charmcraft pack` produces multiple charm files, this change enables the `upload-charm` action to upload and release them all, instead of just one of them.

Closes #106 