### PR TITLE
read metadata from charmcraft.yaml

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42620,8 +42620,14 @@ class Charmcraft {
             };
         });
     }
+    _read() {
+        if (fs.existsSync('metadata.yaml')) {
+            return fs.readFileSync('metadata.yaml');
+        }
+        return fs.readFileSync('charmcraft.yaml');
+    }
     metadata() {
-        const buffer = fs.readFileSync('metadata.yaml');
+        const buffer = this._read();
         const metadata = yaml.load(buffer.toString());
         const resources = Object.entries(metadata.resources || {});
         const files = resources

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -42815,8 +42815,14 @@ class Charmcraft {
             };
         });
     }
+    _read() {
+        if (fs.existsSync('metadata.yaml')) {
+            return fs.readFileSync('metadata.yaml');
+        }
+        return fs.readFileSync('charmcraft.yaml');
+    }
     metadata() {
-        const buffer = fs.readFileSync('metadata.yaml');
+        const buffer = this._read();
         const metadata = yaml.load(buffer.toString());
         const resources = Object.entries(metadata.resources || {});
         const files = resources

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42711,8 +42711,14 @@ class Charmcraft {
             };
         });
     }
+    _read() {
+        if (fs.existsSync('metadata.yaml')) {
+            return fs.readFileSync('metadata.yaml');
+        }
+        return fs.readFileSync('charmcraft.yaml');
+    }
     metadata() {
-        const buffer = fs.readFileSync('metadata.yaml');
+        const buffer = this._read();
         const metadata = yaml.load(buffer.toString());
         const resources = Object.entries(metadata.resources || {});
         const files = resources

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -42842,8 +42842,14 @@ class Charmcraft {
             };
         });
     }
+    _read() {
+        if (fs.existsSync('metadata.yaml')) {
+            return fs.readFileSync('metadata.yaml');
+        }
+        return fs.readFileSync('charmcraft.yaml');
+    }
     metadata() {
-        const buffer = fs.readFileSync('metadata.yaml');
+        const buffer = this._read();
         const metadata = yaml.load(buffer.toString());
         const resources = Object.entries(metadata.resources || {});
         const files = resources

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42690,8 +42690,14 @@ class Charmcraft {
             };
         });
     }
+    _read() {
+        if (fs.existsSync('metadata.yaml')) {
+            return fs.readFileSync('metadata.yaml');
+        }
+        return fs.readFileSync('charmcraft.yaml');
+    }
     metadata() {
-        const buffer = fs.readFileSync('metadata.yaml');
+        const buffer = this._read();
         const metadata = yaml.load(buffer.toString());
         const resources = Object.entries(metadata.resources || {});
         const files = resources

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42721,8 +42721,14 @@ class Charmcraft {
             };
         });
     }
+    _read() {
+        if (fs.existsSync('metadata.yaml')) {
+            return fs.readFileSync('metadata.yaml');
+        }
+        return fs.readFileSync('charmcraft.yaml');
+    }
     metadata() {
-        const buffer = fs.readFileSync('metadata.yaml');
+        const buffer = this._read();
         const metadata = yaml.load(buffer.toString());
         const resources = Object.entries(metadata.resources || {});
         const files = resources

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -164,8 +164,15 @@ class Charmcraft {
     };
   }
 
+  _read() {
+    if (fs.existsSync('metadata.yaml')) {
+      return fs.readFileSync('metadata.yaml');
+    }
+    return fs.readFileSync('charmcraft.yaml');
+  }
+
   metadata() {
-    const buffer = fs.readFileSync('metadata.yaml');
+    const buffer = this._read();
     const metadata = yaml.load(buffer.toString()) as Metadata;
     const resources = Object.entries(metadata.resources || {});
 


### PR DESCRIPTION
Charmcraft now supports charms that do not have `metadata.yaml` and these actions fail when run against these style charms.  
Example:
* https://github.com/canonical/k8s-operator/actions/runs/7791969417/job/21249115845

Fortunately, the metadata can be loaded out of `charmcraft.yaml` with the same structure for the most part