### PR TITLE
Add "dump-logs" action

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ of the following actions:
 - [canonical/charming-actions/channel](channel/README.md)
 - [canonical/charming-actions/upload-charm](upload-charm/README.md)
 - [canonical/charming-actions/upload-bundle](upload-bundle/README.md)
+- [canonical/charming-actions/dump-logs](dump-logs/README.md)
 
 ## Usage
 
 > #### ⚠️ Prerequisites
-> 
-> To use these actions, start by adding a repository secret to your Github repository. In 
-> the example below, it's called `CHARMCRAFT_TOKEN`, but can be anything you want. 
-> See https://juju.is/docs/sdk/remote-env-auth for more information 
+>
+> To use these actions, start by adding a repository secret to your Github repository. In
+> the example below, it's called `CHARMCRAFT_TOKEN`, but can be anything you want.
+> See https://juju.is/docs/sdk/remote-env-auth for more information
 > on how to generate the appropriate credentials. `GITHUB_TOKEN` does not need to be explicitly
 > added to the repository secrets as GitHub Actions will generate a context-bound token for
 > each workflow execution.
@@ -27,7 +28,7 @@ The below snippet illustrates how to use the actions of the collection in a PR w
 
 name: Pull Request
 
-on: 
+on:
   pull_request:
     branches:
       - main
@@ -40,7 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0  
+          fetch-depth: 0
       - name: Check libraries
         uses: canonical/charming-actions/check-libraries@2.2.0
         with:
@@ -86,8 +87,8 @@ jobs:
 
 ## Development
 
-To be able to contribute to this repository, you first need to make sure you have 
-`npm` and `nodejs` installed in your local development environment. This installation varies 
+To be able to contribute to this repository, you first need to make sure you have
+`npm` and `nodejs` installed in your local development environment. This installation varies
 depending on the OS and distribution you are using. For more detailed instructions, see [the official NodeJS page](https://nodejs.org/).
 
 Once that is done, start by cloning the repository:

--- a/dump-logs/README.md
+++ b/dump-logs/README.md
@@ -1,0 +1,29 @@
+## Summary
+
+This action collects logs from juju models and k8s objects.
+
+This action is relevant for workflows that run charm integration tests.
+
+### Inputs
+None
+
+### Outputs
+None
+
+## Example usage
+
+Example workflow:
+
+```yaml
+jobs:
+  integration-test:
+    steps:
+      - name: Set up and run some tests
+      - name: Dump logs
+        if: failure()
+        uses: canonical/charming-actions/dump-logs
+```
+
+## Known issues
+- If pytest operator is not told to keep models (`--keep-models`) then some
+  resources may be destroyed before the logs collection completes.

--- a/dump-logs/action.yml
+++ b/dump-logs/action.yml
@@ -1,0 +1,46 @@
+name: "Dump logs"
+description: "Collects all charm and k8s logs"
+
+runs:
+  using: "composite"
+  steps:
+  - name: Dump debug log
+    run: |
+      for ctl in $(juju controllers --format json | jq -r '.controllers | keys[]'); do for mdl in $(juju models --format json | jq -r '.models[].name' | grep -v "admin/controller"); do juju debug-log -m $ctl:$mdl --replay --ms --no-tail; done; done || true
+      exit 0
+    shell: bash
+  - name: Dump pods and their logs
+    shell: bash
+    run: |
+      juju status --relations --storage
+      kubectl get pods \
+          -A \
+          -o=jsonpath='{range.items[*]}{.metadata.namespace} {.metadata.name}{"\n"}' \
+          --sort-by=.metadata.namespace \
+          | grep -v "^\s*$" \
+          | while read namespace pod; do \
+               kubectl -n $namespace describe pod $pod; \
+               kubectl -n $namespace logs $pod \
+                  --all-containers=true \
+                  --tail=100; \
+           done
+  - name: Dump deployments
+    run: |
+      kubectl describe deployments -A
+      exit 0
+    shell: bash
+  - name: Dump replicasets
+    run: |
+      kubectl describe replicasets -A
+      exit 0
+    shell: bash
+  - name: Dump node information
+    run: |
+      kubectl get nodes -v=10
+      exit 0
+    shell: bash
+  - name: Dump charmcraft logs
+    uses: actions/upload-artifact@v3
+    with:
+      name: charmcraft-logs
+      path: ~/.local/state/charmcraft/log/*.log


### PR DESCRIPTION
This PR adds a general purpose log dump action.
Unlike [canonical/charm-logdump-action](https://github.com/canonical/charm-logdump-action), this action does not make any assumption on (or requires an input for) the model name.
This is particularly useful for end-to-end tests where multiple controllers are bootstrapped. [Example](https://github.com/canonical/cos-lite-bundle/blob/0bd04b8d30ded073592554daca3b74f2c3bb0ffe/.github/workflows/ci.yaml#L101).