### PR TITLE
make github tag in upload-charm optional

### DIFF
--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42299,6 +42299,7 @@ class UploadCharmAction {
         this.tagPrefix = core.getInput('tag-prefix');
         this.token = core.getInput('github-token');
         this.destructive = core.getBooleanInput('destructive-mode');
+        this.githubTag = core.getBooleanInput('github-tag');
         if (!this.token) {
             throw new Error(`Input 'github-token' is missing`);
         }
@@ -42344,7 +42345,9 @@ class UploadCharmAction {
                 yield charms.reduce((previousUpload, charm) => __awaiter(this, void 0, void 0, function* () {
                     yield previousUpload;
                     const rev = yield this.charmcraft.upload(charm, this.channel, flags);
-                    yield this.tagger.tag(rev, this.channel, resourceInfo, this.tagPrefix);
+                    if (this.githubTag) {
+                        yield this.tagger.tag(rev, this.channel, resourceInfo, this.tagPrefix);
+                    }
                 }), Promise.resolve());
             }
             catch (error) {

--- a/src/actions/upload-charm/upload-charm.ts
+++ b/src/actions/upload-charm/upload-charm.ts
@@ -16,6 +16,7 @@ export class UploadCharmAction {
   private charmPath: string;
   private tagPrefix?: string;
   private token: string;
+  private githubTag: boolean;
 
   constructor() {
     this.channel = core.getInput('channel');
@@ -25,6 +26,7 @@ export class UploadCharmAction {
     this.tagPrefix = core.getInput('tag-prefix');
     this.token = core.getInput('github-token');
     this.destructive = core.getBooleanInput('destructive-mode');
+    this.githubTag = core.getBooleanInput('github-tag');
 
     if (!this.token) {
       throw new Error(`Input 'github-token' is missing`);
@@ -82,7 +84,14 @@ export class UploadCharmAction {
       await charms.reduce(async (previousUpload, charm) => {
         await previousUpload;
         const rev = await this.charmcraft.upload(charm, this.channel, flags);
-        await this.tagger.tag(rev, this.channel, resourceInfo, this.tagPrefix);
+        if (this.githubTag) {
+          await this.tagger.tag(
+            rev,
+            this.channel,
+            resourceInfo,
+            this.tagPrefix,
+          );
+        }
       }, Promise.resolve());
     } catch (error: any) {
       core.setFailed(error.message);

--- a/upload-charm/README.md
+++ b/upload-charm/README.md
@@ -5,20 +5,22 @@ This action is used to upload a charm to charmhub.io.
 ## Usage
 
 ```yaml
-      - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@1.0.0
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.channel.outputs.name }}"
+- name: Upload charm to charmhub
+  uses: canonical/charming-actions/upload-charm@1.0.0
+  with:
+    credentials: '${{ secrets.CHARMHUB_TOKEN }}'
+    github-token: '${{ secrets.GITHUB_TOKEN }}'
+    channel: '${{ steps.channel.outputs.name }}'
 ```
 
 ## Charm Resources
+
 ### OCI Image
 
 When uploading a charm with OCI image resources, a new revision of the OCI image will be published
 and attached to the release. It is possible to disable this behavior using either `upload-image: false`
 or by providing `resource-overrides` pointing at a specific existing revision.
+
 ### Files
 
 When uploading a charm with file resources, the most recent resource will be attached to the release.
@@ -29,18 +31,19 @@ If you want to use a new resource, you'll have to cut a new resource revision **
 ### Inputs
 
 | Key                  | Description                                                                                                      | Required |
-|----------------------|------------------------------------------------------------------------------------------------------------------| -------- |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- |
 | `charm-path`         | Path to the charm we want to publish. Defaults to the current working directory.                                 |          |
 | `built-charm-path`   | Path to a pre-built charm we want to publish.                                                                    |          |
 | `channel`            | Channel on charmhub to publish the charm in. Defaults to `latest/edge`.                                          |          |
-| `credentials`        | Credentials [exported](https://juju.is/docs/sdk/remote-env-auth) using `charmcraft login --export`.              | ✔️        |
+| `credentials`        | Credentials [exported](https://juju.is/docs/sdk/remote-env-auth) using `charmcraft login --export`.              | ✔️       |
 | `destructive-mode`   | Whether or not to pack using destructive mode. Defaults to `true`.                                               |          |
-| `github-token`       | Github Token needed for automatic tagging when publishing                                                        | ✔️        |
+| `github-token`       | Github Token needed for automatic tagging when publishing                                                        | ✔️       |
 | `tag-prefix`         | Tag prefix, useful when bundling multiple charms in the same repo using a matrix.                                |          |
 | `upload-image`       | Toggles whether image resources are uploaded to CharmHub or not. Defaults to `true`.                             |          |
 | `pull-image`         | Toggles whether image resources are pulled. Defaults to `true`.                                                  |          |
 | `charmcraft-channel` | Snap channel to use when installing charmcraft. Defaults to `latest/edge`.                                       |          |
 | `resource-overrides` | Charm resource revision overrides. Separate entries using commas, ie. `"promql-transform:2,prometheus-image:12"` |          |
+
 ### Outputs
 
 None

--- a/upload-charm/action.yaml
+++ b/upload-charm/action.yaml
@@ -54,14 +54,20 @@ inputs:
     required: true
     description: |
       Github Token needed for automatic tagging when publishing
+  github-tag:
+    required: false
+    default: true
+    description: |
+      Set to false if you don't want to create a GitHub tag and release
+      when uploading the charm.
   resource-overrides:
     required: false
-    default: ""
+    default: ''
     description: |
       Assign static charm resource revisions. If omitted, the latest
       revision will be used. Separate entries using commas.
-      
-      Example: "promql-transform:2,prometheus-image:12"   
+
+      Example: "promql-transform:2,prometheus-image:12"
 runs:
   using: node20
   main: ../dist/upload-charm/index.js


### PR DESCRIPTION
## Issue

The `upload-charm` action cannot be used to upload temporary Charmhub releases (e.g., publish a charm to `latest/edge/temp-123`), because it automatically creates a GitHub tag (and release) whenever it's called; this obviously doesn't suit temporary releases.

## Solution

Make the GitHub tagging process optional, by adding an extra (optional) input to the action.

(p.s. the unrelated edits are from the pre-commit hook running `prettier`)