### PR TITLE
Support charms using charmcraft extensions

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42838,7 +42838,7 @@ class Charmcraft {
             };
         });
     }
-    _readMetadata() {
+    readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
             return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
@@ -42853,11 +42853,11 @@ class Charmcraft {
         });
     }
     charmName() {
-        return this._readMetadata().name;
+        return this.readMetadata().name;
     }
     metadata() {
         return __awaiter(this, void 0, void 0, function* () {
-            let metadata = this._readMetadata();
+            let metadata = this.readMetadata();
             if (metadata.extensions) {
                 metadata = yaml.load(yield this.expandExtensions());
             }

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42750,7 +42750,7 @@ class Charmcraft {
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }
-            const { name: charmName, images } = this.metadata();
+            const { name: charmName, images } = yield this.metadata();
             const flags = [];
             yield Promise.all(images
                 // If an image resource has been overridden in the action input,
@@ -42771,7 +42771,7 @@ class Charmcraft {
     }
     fetchFileFlags(overrides) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name: charmName, files } = this.metadata();
+            const { name: charmName, files } = yield this.metadata();
             // If an image resource has been overridden in the action input,
             // we don't want to upload a new version of it either.
             const filtered = files.filter(([name]) => !overrides || !Object.keys(overrides).includes(name));
@@ -42838,27 +42838,42 @@ class Charmcraft {
             };
         });
     }
-    _read() {
+    _readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
-            return fs.readFileSync('metadata.yaml');
+            return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
-        return fs.readFileSync('charmcraft.yaml');
+        return yaml.load(fs.readFileSync('charmcraft.yaml', 'utf8'));
+    }
+    expandExtensions() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const output = yield (0, exec_1.getExecOutput)('charmcraft', ['expand-extensions'], {
+                silent: true,
+            });
+            return output.stdout;
+        });
+    }
+    charmName() {
+        return this._readMetadata().name;
     }
     metadata() {
-        const buffer = this._read();
-        const metadata = yaml.load(buffer.toString());
-        const resources = Object.entries(metadata.resources || {});
-        const files = resources
-            .filter(([, res]) => res.type === 'file')
-            .map(([name]) => name);
-        const images = resources
-            .filter(([, res]) => res.type === 'oci-image')
-            .map(([name, res]) => [name, res['upstream-source']]);
-        return {
-            images,
-            files,
-            name: metadata.name,
-        };
+        return __awaiter(this, void 0, void 0, function* () {
+            let metadata = this._readMetadata();
+            if (metadata.extensions) {
+                metadata = yaml.load(yield this.expandExtensions());
+            }
+            const resources = Object.entries(metadata.resources || {});
+            const files = resources
+                .filter(([, res]) => res.type === 'file')
+                .map(([name]) => name);
+            const images = resources
+                .filter(([, res]) => res.type === 'oci-image')
+                .map(([name, res]) => [name, res['upstream-source']]);
+            return {
+                images,
+                files,
+                name: metadata.name,
+            };
+        });
     }
     pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -42891,7 +42906,7 @@ class Charmcraft {
     }
     hasDriftingLibs() {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name } = this.metadata();
+            const { name } = yield this.metadata();
             const args = ['fetch-lib'];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
             const re = new RegExp(`${name}`);

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -42945,7 +42945,7 @@ class Charmcraft {
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }
-            const { name: charmName, images } = this.metadata();
+            const { name: charmName, images } = yield this.metadata();
             const flags = [];
             yield Promise.all(images
                 // If an image resource has been overridden in the action input,
@@ -42966,7 +42966,7 @@ class Charmcraft {
     }
     fetchFileFlags(overrides) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name: charmName, files } = this.metadata();
+            const { name: charmName, files } = yield this.metadata();
             // If an image resource has been overridden in the action input,
             // we don't want to upload a new version of it either.
             const filtered = files.filter(([name]) => !overrides || !Object.keys(overrides).includes(name));
@@ -43033,27 +43033,42 @@ class Charmcraft {
             };
         });
     }
-    _read() {
+    _readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
-            return fs.readFileSync('metadata.yaml');
+            return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
-        return fs.readFileSync('charmcraft.yaml');
+        return yaml.load(fs.readFileSync('charmcraft.yaml', 'utf8'));
+    }
+    expandExtensions() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const output = yield (0, exec_1.getExecOutput)('charmcraft', ['expand-extensions'], {
+                silent: true,
+            });
+            return output.stdout;
+        });
+    }
+    charmName() {
+        return this._readMetadata().name;
     }
     metadata() {
-        const buffer = this._read();
-        const metadata = yaml.load(buffer.toString());
-        const resources = Object.entries(metadata.resources || {});
-        const files = resources
-            .filter(([, res]) => res.type === 'file')
-            .map(([name]) => name);
-        const images = resources
-            .filter(([, res]) => res.type === 'oci-image')
-            .map(([name, res]) => [name, res['upstream-source']]);
-        return {
-            images,
-            files,
-            name: metadata.name,
-        };
+        return __awaiter(this, void 0, void 0, function* () {
+            let metadata = this._readMetadata();
+            if (metadata.extensions) {
+                metadata = yaml.load(yield this.expandExtensions());
+            }
+            const resources = Object.entries(metadata.resources || {});
+            const files = resources
+                .filter(([, res]) => res.type === 'file')
+                .map(([name]) => name);
+            const images = resources
+                .filter(([, res]) => res.type === 'oci-image')
+                .map(([name, res]) => [name, res['upstream-source']]);
+            return {
+                images,
+                files,
+                name: metadata.name,
+            };
+        });
     }
     pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -43086,7 +43101,7 @@ class Charmcraft {
     }
     hasDriftingLibs() {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name } = this.metadata();
+            const { name } = yield this.metadata();
             const args = ['fetch-lib'];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
             const re = new RegExp(`${name}`);

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -43033,7 +43033,7 @@ class Charmcraft {
             };
         });
     }
-    _readMetadata() {
+    readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
             return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
@@ -43048,11 +43048,11 @@ class Charmcraft {
         });
     }
     charmName() {
-        return this._readMetadata().name;
+        return this.readMetadata().name;
     }
     metadata() {
         return __awaiter(this, void 0, void 0, function* () {
-            let metadata = this._readMetadata();
+            let metadata = this.readMetadata();
             if (metadata.extensions) {
                 metadata = yaml.load(yield this.expandExtensions());
             }

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42917,7 +42917,7 @@ class Charmcraft {
             };
         });
     }
-    _readMetadata() {
+    readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
             return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
@@ -42932,11 +42932,11 @@ class Charmcraft {
         });
     }
     charmName() {
-        return this._readMetadata().name;
+        return this.readMetadata().name;
     }
     metadata() {
         return __awaiter(this, void 0, void 0, function* () {
-            let metadata = this._readMetadata();
+            let metadata = this.readMetadata();
             if (metadata.extensions) {
                 metadata = yaml.load(yield this.expandExtensions());
             }

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42529,7 +42529,7 @@ class PromoteCharmAction {
             try {
                 yield this.snap.install('charmcraft', this.charmcraftChannel);
                 process.chdir(this.charmPath);
-                const { name: charmName } = this.charmcraft.metadata();
+                const charmName = this.charmcraft.charmName();
                 const [originTrack, originChannel] = this.originChannel.split('/');
                 const basesArray = yield this.charmcraft.getBases(charmName, originTrack);
                 const revisions = yield this.getRevisions(charmName, originTrack, originChannel, basesArray);
@@ -42829,7 +42829,7 @@ class Charmcraft {
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }
-            const { name: charmName, images } = this.metadata();
+            const { name: charmName, images } = yield this.metadata();
             const flags = [];
             yield Promise.all(images
                 // If an image resource has been overridden in the action input,
@@ -42850,7 +42850,7 @@ class Charmcraft {
     }
     fetchFileFlags(overrides) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name: charmName, files } = this.metadata();
+            const { name: charmName, files } = yield this.metadata();
             // If an image resource has been overridden in the action input,
             // we don't want to upload a new version of it either.
             const filtered = files.filter(([name]) => !overrides || !Object.keys(overrides).includes(name));
@@ -42917,27 +42917,42 @@ class Charmcraft {
             };
         });
     }
-    _read() {
+    _readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
-            return fs.readFileSync('metadata.yaml');
+            return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
-        return fs.readFileSync('charmcraft.yaml');
+        return yaml.load(fs.readFileSync('charmcraft.yaml', 'utf8'));
+    }
+    expandExtensions() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const output = yield (0, exec_1.getExecOutput)('charmcraft', ['expand-extensions'], {
+                silent: true,
+            });
+            return output.stdout;
+        });
+    }
+    charmName() {
+        return this._readMetadata().name;
     }
     metadata() {
-        const buffer = this._read();
-        const metadata = yaml.load(buffer.toString());
-        const resources = Object.entries(metadata.resources || {});
-        const files = resources
-            .filter(([, res]) => res.type === 'file')
-            .map(([name]) => name);
-        const images = resources
-            .filter(([, res]) => res.type === 'oci-image')
-            .map(([name, res]) => [name, res['upstream-source']]);
-        return {
-            images,
-            files,
-            name: metadata.name,
-        };
+        return __awaiter(this, void 0, void 0, function* () {
+            let metadata = this._readMetadata();
+            if (metadata.extensions) {
+                metadata = yaml.load(yield this.expandExtensions());
+            }
+            const resources = Object.entries(metadata.resources || {});
+            const files = resources
+                .filter(([, res]) => res.type === 'file')
+                .map(([name]) => name);
+            const images = resources
+                .filter(([, res]) => res.type === 'oci-image')
+                .map(([name, res]) => [name, res['upstream-source']]);
+            return {
+                images,
+                files,
+                name: metadata.name,
+            };
+        });
     }
     pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -42970,7 +42985,7 @@ class Charmcraft {
     }
     hasDriftingLibs() {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name } = this.metadata();
+            const { name } = yield this.metadata();
             const args = ['fetch-lib'];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
             const re = new RegExp(`${name}`);

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42929,7 +42929,7 @@ class Charmcraft {
             };
         });
     }
-    _readMetadata() {
+    readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
             return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
@@ -42944,11 +42944,11 @@ class Charmcraft {
         });
     }
     charmName() {
-        return this._readMetadata().name;
+        return this.readMetadata().name;
     }
     metadata() {
         return __awaiter(this, void 0, void 0, function* () {
-            let metadata = this._readMetadata();
+            let metadata = this.readMetadata();
             if (metadata.extensions) {
                 metadata = yaml.load(yield this.expandExtensions());
             }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42532,7 +42532,7 @@ class ReleaseCharmAction {
             try {
                 yield this.snap.install('charmcraft', this.charmcraftChannel);
                 process.chdir(this.charmPath);
-                const { name: charmName } = this.charmcraft.metadata();
+                const { name: charmName } = yield this.charmcraft.metadata();
                 const [originTrack, originChannel] = this.originChannel.split('/');
                 const base = {
                     name: this.baseName,
@@ -42841,7 +42841,7 @@ class Charmcraft {
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }
-            const { name: charmName, images } = this.metadata();
+            const { name: charmName, images } = yield this.metadata();
             const flags = [];
             yield Promise.all(images
                 // If an image resource has been overridden in the action input,
@@ -42862,7 +42862,7 @@ class Charmcraft {
     }
     fetchFileFlags(overrides) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name: charmName, files } = this.metadata();
+            const { name: charmName, files } = yield this.metadata();
             // If an image resource has been overridden in the action input,
             // we don't want to upload a new version of it either.
             const filtered = files.filter(([name]) => !overrides || !Object.keys(overrides).includes(name));
@@ -42929,27 +42929,42 @@ class Charmcraft {
             };
         });
     }
-    _read() {
+    _readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
-            return fs.readFileSync('metadata.yaml');
+            return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
-        return fs.readFileSync('charmcraft.yaml');
+        return yaml.load(fs.readFileSync('charmcraft.yaml', 'utf8'));
+    }
+    expandExtensions() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const output = yield (0, exec_1.getExecOutput)('charmcraft', ['expand-extensions'], {
+                silent: true,
+            });
+            return output.stdout;
+        });
+    }
+    charmName() {
+        return this._readMetadata().name;
     }
     metadata() {
-        const buffer = this._read();
-        const metadata = yaml.load(buffer.toString());
-        const resources = Object.entries(metadata.resources || {});
-        const files = resources
-            .filter(([, res]) => res.type === 'file')
-            .map(([name]) => name);
-        const images = resources
-            .filter(([, res]) => res.type === 'oci-image')
-            .map(([name, res]) => [name, res['upstream-source']]);
-        return {
-            images,
-            files,
-            name: metadata.name,
-        };
+        return __awaiter(this, void 0, void 0, function* () {
+            let metadata = this._readMetadata();
+            if (metadata.extensions) {
+                metadata = yaml.load(yield this.expandExtensions());
+            }
+            const resources = Object.entries(metadata.resources || {});
+            const files = resources
+                .filter(([, res]) => res.type === 'file')
+                .map(([name]) => name);
+            const images = resources
+                .filter(([, res]) => res.type === 'oci-image')
+                .map(([name, res]) => [name, res['upstream-source']]);
+            return {
+                images,
+                files,
+                name: metadata.name,
+            };
+        });
     }
     pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -42982,7 +42997,7 @@ class Charmcraft {
     }
     hasDriftingLibs() {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name } = this.metadata();
+            const { name } = yield this.metadata();
             const args = ['fetch-lib'];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
             const re = new RegExp(`${name}`);

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -43060,7 +43060,7 @@ class Charmcraft {
             };
         });
     }
-    _readMetadata() {
+    readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
             return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
@@ -43075,11 +43075,11 @@ class Charmcraft {
         });
     }
     charmName() {
-        return this._readMetadata().name;
+        return this.readMetadata().name;
     }
     metadata() {
         return __awaiter(this, void 0, void 0, function* () {
-            let metadata = this._readMetadata();
+            let metadata = this.readMetadata();
             if (metadata.extensions) {
                 metadata = yaml.load(yield this.expandExtensions());
             }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42820,7 +42820,7 @@ class Charmcraft {
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }
-            const { name: charmName, images } = this.metadata();
+            const { name: charmName, images } = yield this.metadata();
             const flags = [];
             yield Promise.all(images
                 // If an image resource has been overridden in the action input,
@@ -42841,7 +42841,7 @@ class Charmcraft {
     }
     fetchFileFlags(overrides) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name: charmName, files } = this.metadata();
+            const { name: charmName, files } = yield this.metadata();
             // If an image resource has been overridden in the action input,
             // we don't want to upload a new version of it either.
             const filtered = files.filter(([name]) => !overrides || !Object.keys(overrides).includes(name));
@@ -42908,27 +42908,42 @@ class Charmcraft {
             };
         });
     }
-    _read() {
+    _readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
-            return fs.readFileSync('metadata.yaml');
+            return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
-        return fs.readFileSync('charmcraft.yaml');
+        return yaml.load(fs.readFileSync('charmcraft.yaml', 'utf8'));
+    }
+    expandExtensions() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const output = yield (0, exec_1.getExecOutput)('charmcraft', ['expand-extensions'], {
+                silent: true,
+            });
+            return output.stdout;
+        });
+    }
+    charmName() {
+        return this._readMetadata().name;
     }
     metadata() {
-        const buffer = this._read();
-        const metadata = yaml.load(buffer.toString());
-        const resources = Object.entries(metadata.resources || {});
-        const files = resources
-            .filter(([, res]) => res.type === 'file')
-            .map(([name]) => name);
-        const images = resources
-            .filter(([, res]) => res.type === 'oci-image')
-            .map(([name, res]) => [name, res['upstream-source']]);
-        return {
-            images,
-            files,
-            name: metadata.name,
-        };
+        return __awaiter(this, void 0, void 0, function* () {
+            let metadata = this._readMetadata();
+            if (metadata.extensions) {
+                metadata = yaml.load(yield this.expandExtensions());
+            }
+            const resources = Object.entries(metadata.resources || {});
+            const files = resources
+                .filter(([, res]) => res.type === 'file')
+                .map(([name]) => name);
+            const images = resources
+                .filter(([, res]) => res.type === 'oci-image')
+                .map(([name, res]) => [name, res['upstream-source']]);
+            return {
+                images,
+                files,
+                name: metadata.name,
+            };
+        });
     }
     pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -42961,7 +42976,7 @@ class Charmcraft {
     }
     hasDriftingLibs() {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name } = this.metadata();
+            const { name } = yield this.metadata();
             const args = ['fetch-lib'];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
             const re = new RegExp(`${name}`);

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42908,7 +42908,7 @@ class Charmcraft {
             };
         });
     }
-    _readMetadata() {
+    readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
             return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
@@ -42923,11 +42923,11 @@ class Charmcraft {
         });
     }
     charmName() {
-        return this._readMetadata().name;
+        return this.readMetadata().name;
     }
     metadata() {
         return __awaiter(this, void 0, void 0, function* () {
-            let metadata = this._readMetadata();
+            let metadata = this.readMetadata();
             if (metadata.extensions) {
                 metadata = yaml.load(yield this.expandExtensions());
             }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42948,7 +42948,7 @@ class Charmcraft {
             };
         });
     }
-    _readMetadata() {
+    readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
             return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
@@ -42963,11 +42963,11 @@ class Charmcraft {
         });
     }
     charmName() {
-        return this._readMetadata().name;
+        return this.readMetadata().name;
     }
     metadata() {
         return __awaiter(this, void 0, void 0, function* () {
-            let metadata = this._readMetadata();
+            let metadata = this.readMetadata();
             if (metadata.extensions) {
                 metadata = yaml.load(yield this.expandExtensions());
             }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42860,7 +42860,7 @@ class Charmcraft {
                     `If you wish to upload the OCI image, set 'upload-image' to 'true'`;
                 core.warning(msg);
             }
-            const { name: charmName, images } = this.metadata();
+            const { name: charmName, images } = yield this.metadata();
             const flags = [];
             yield Promise.all(images
                 // If an image resource has been overridden in the action input,
@@ -42881,7 +42881,7 @@ class Charmcraft {
     }
     fetchFileFlags(overrides) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name: charmName, files } = this.metadata();
+            const { name: charmName, files } = yield this.metadata();
             // If an image resource has been overridden in the action input,
             // we don't want to upload a new version of it either.
             const filtered = files.filter(([name]) => !overrides || !Object.keys(overrides).includes(name));
@@ -42948,27 +42948,42 @@ class Charmcraft {
             };
         });
     }
-    _read() {
+    _readMetadata() {
         if (fs.existsSync('metadata.yaml')) {
-            return fs.readFileSync('metadata.yaml');
+            return yaml.load(fs.readFileSync('metadata.yaml', 'utf8'));
         }
-        return fs.readFileSync('charmcraft.yaml');
+        return yaml.load(fs.readFileSync('charmcraft.yaml', 'utf8'));
+    }
+    expandExtensions() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const output = yield (0, exec_1.getExecOutput)('charmcraft', ['expand-extensions'], {
+                silent: true,
+            });
+            return output.stdout;
+        });
+    }
+    charmName() {
+        return this._readMetadata().name;
     }
     metadata() {
-        const buffer = this._read();
-        const metadata = yaml.load(buffer.toString());
-        const resources = Object.entries(metadata.resources || {});
-        const files = resources
-            .filter(([, res]) => res.type === 'file')
-            .map(([name]) => name);
-        const images = resources
-            .filter(([, res]) => res.type === 'oci-image')
-            .map(([name, res]) => [name, res['upstream-source']]);
-        return {
-            images,
-            files,
-            name: metadata.name,
-        };
+        return __awaiter(this, void 0, void 0, function* () {
+            let metadata = this._readMetadata();
+            if (metadata.extensions) {
+                metadata = yaml.load(yield this.expandExtensions());
+            }
+            const resources = Object.entries(metadata.resources || {});
+            const files = resources
+                .filter(([, res]) => res.type === 'file')
+                .map(([name]) => name);
+            const images = resources
+                .filter(([, res]) => res.type === 'oci-image')
+                .map(([name, res]) => [name, res['upstream-source']]);
+            return {
+                images,
+                files,
+                name: metadata.name,
+            };
+        });
     }
     pack(destructive) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -43001,7 +43016,7 @@ class Charmcraft {
     }
     hasDriftingLibs() {
         return __awaiter(this, void 0, void 0, function* () {
-            const { name } = this.metadata();
+            const { name } = yield this.metadata();
             const args = ['fetch-lib'];
             const result = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
             const re = new RegExp(`${name}`);

--- a/src/actions/promote-charm/promote-charm.ts
+++ b/src/actions/promote-charm/promote-charm.ts
@@ -48,7 +48,7 @@ export class PromoteCharmAction {
     try {
       await this.snap.install('charmcraft', this.charmcraftChannel);
       process.chdir(this.charmPath!);
-      const { name: charmName } = this.charmcraft.metadata();
+      const charmName = this.charmcraft.charmName();
 
       const [originTrack, originChannel] = this.originChannel.split('/');
 

--- a/src/actions/release-charm/release-charm.ts
+++ b/src/actions/release-charm/release-charm.ts
@@ -43,7 +43,7 @@ export class ReleaseCharmAction {
     try {
       await this.snap.install('charmcraft', this.charmcraftChannel);
       process.chdir(this.charmPath!);
-      const { name: charmName } = this.charmcraft.metadata();
+      const { name: charmName } = await this.charmcraft.metadata();
 
       const [originTrack, originChannel] = this.originChannel.split('/');
 

--- a/src/actions/release-libraries/release-libraries.ts
+++ b/src/actions/release-libraries/release-libraries.ts
@@ -42,7 +42,7 @@ export class ReleaseLibrariesAction {
     process.chdir(this.charmPath!);
 
     this.charmcraft = new Charmcraft(this.tokens.charmhub);
-    this.charmName = this.charmcraft.metadata().name;
+    this.charmName = this.charmcraft.charmName();
     this.charmNamePy = this.charmName.split('-').join('_'); // replace all
     this.snap = new Snap();
   }

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -164,7 +164,7 @@ class Charmcraft {
     };
   }
 
-  _readMetadata(): Metadata {
+  private readMetadata(): Metadata {
     if (fs.existsSync('metadata.yaml')) {
       return yaml.load(fs.readFileSync('metadata.yaml', 'utf8')) as Metadata;
     }
@@ -179,11 +179,11 @@ class Charmcraft {
   }
 
   charmName(): string {
-    return this._readMetadata().name;
+    return this.readMetadata().name;
   }
 
   async metadata() {
-    let metadata = this._readMetadata();
+    let metadata = this.readMetadata();
     if (metadata.extensions) {
       metadata = yaml.load(await this.expandExtensions()) as Metadata;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type PullRequestMetadata = {
 export type Metadata = {
   name: string;
   resources: { [key: string]: Resource };
+  extensions?: string[];
 };
 
 export interface Tokens {


### PR DESCRIPTION
Charmcraft now supports extensions (https://discourse.charmhub.io/t/manage-extensions/13788), similar to Snapcraft extensions. These are built-in Python modules that can modify the contents of `charmcraft.yaml`, reducing boilerplate for charms that share common functionalities. Consequently, extensions can alter certain charm metadata, such as resources.

In the pull request, update the charming actions to apply extensions when necessary before getting charm metadata.