### PR TITLE
fix(upload-charm): Use resource revision from upload-resource command

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42758,13 +42758,24 @@ class Charmcraft {
                 .filter(([name]) => !overrides || !Object.keys(overrides).includes(name))
                 .map(([name, image]) => __awaiter(this, void 0, void 0, function* () {
                 if (this.uploadImage) {
-                    yield this.uploadResource(image, charmName, name);
+                    const { exitCode, stdout, stderr } = yield this.uploadResource(image, charmName, name);
+                    if (exitCode !== 0) {
+                        throw new Error(`Could not upload resource with error ${stderr}`);
+                    }
+                    const { revision } = JSON.parse(stdout);
+                    const flag = `--resource=${name}:${revision}`;
+                    const info = `    -  ${name}: ${image}\n` +
+                        `       resource-revision: ${revision}\n`;
+                    flags.push(flag);
+                    resourceInfo += info;
                 }
-                const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
-                if (!resourceFlag)
-                    return;
-                flags.push(resourceFlag.flag);
-                resourceInfo += resourceFlag.info;
+                else {
+                    const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
+                    if (!resourceFlag)
+                        return;
+                    flags.push(resourceFlag.flag);
+                    resourceInfo += resourceFlag.info;
+                }
             })));
             return { flags, resourceInfo };
         });
@@ -42806,13 +42817,15 @@ class Charmcraft {
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
-                '--quiet',
+                '--format',
+                'json',
                 name,
                 resource_name,
                 '--image',
                 resourceDigest,
             ];
-            yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
+            const execOutput = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
+            return execOutput;
         });
     }
     buildResourceFlag(charmName, name, image) {

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42837,13 +42837,24 @@ class Charmcraft {
                 .filter(([name]) => !overrides || !Object.keys(overrides).includes(name))
                 .map(([name, image]) => __awaiter(this, void 0, void 0, function* () {
                 if (this.uploadImage) {
-                    yield this.uploadResource(image, charmName, name);
+                    const { exitCode, stdout, stderr } = yield this.uploadResource(image, charmName, name);
+                    if (exitCode !== 0) {
+                        throw new Error(`Could not upload resource with error ${stderr}`);
+                    }
+                    const { revision } = JSON.parse(stdout);
+                    const flag = `--resource=${name}:${revision}`;
+                    const info = `    -  ${name}: ${image}\n` +
+                        `       resource-revision: ${revision}\n`;
+                    flags.push(flag);
+                    resourceInfo += info;
                 }
-                const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
-                if (!resourceFlag)
-                    return;
-                flags.push(resourceFlag.flag);
-                resourceInfo += resourceFlag.info;
+                else {
+                    const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
+                    if (!resourceFlag)
+                        return;
+                    flags.push(resourceFlag.flag);
+                    resourceInfo += resourceFlag.info;
+                }
             })));
             return { flags, resourceInfo };
         });
@@ -42885,13 +42896,15 @@ class Charmcraft {
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
-                '--quiet',
+                '--format',
+                'json',
                 name,
                 resource_name,
                 '--image',
                 resourceDigest,
             ];
-            yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
+            const execOutput = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
+            return execOutput;
         });
     }
     buildResourceFlag(charmName, name, image) {

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42849,13 +42849,24 @@ class Charmcraft {
                 .filter(([name]) => !overrides || !Object.keys(overrides).includes(name))
                 .map(([name, image]) => __awaiter(this, void 0, void 0, function* () {
                 if (this.uploadImage) {
-                    yield this.uploadResource(image, charmName, name);
+                    const { exitCode, stdout, stderr } = yield this.uploadResource(image, charmName, name);
+                    if (exitCode !== 0) {
+                        throw new Error(`Could not upload resource with error ${stderr}`);
+                    }
+                    const { revision } = JSON.parse(stdout);
+                    const flag = `--resource=${name}:${revision}`;
+                    const info = `    -  ${name}: ${image}\n` +
+                        `       resource-revision: ${revision}\n`;
+                    flags.push(flag);
+                    resourceInfo += info;
                 }
-                const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
-                if (!resourceFlag)
-                    return;
-                flags.push(resourceFlag.flag);
-                resourceInfo += resourceFlag.info;
+                else {
+                    const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
+                    if (!resourceFlag)
+                        return;
+                    flags.push(resourceFlag.flag);
+                    resourceInfo += resourceFlag.info;
+                }
             })));
             return { flags, resourceInfo };
         });
@@ -42897,13 +42908,15 @@ class Charmcraft {
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
-                '--quiet',
+                '--format',
+                'json',
                 name,
                 resource_name,
                 '--image',
                 resourceDigest,
             ];
-            yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
+            const execOutput = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
+            return execOutput;
         });
     }
     buildResourceFlag(charmName, name, image) {

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -42980,13 +42980,24 @@ class Charmcraft {
                 .filter(([name]) => !overrides || !Object.keys(overrides).includes(name))
                 .map(([name, image]) => __awaiter(this, void 0, void 0, function* () {
                 if (this.uploadImage) {
-                    yield this.uploadResource(image, charmName, name);
+                    const { exitCode, stdout, stderr } = yield this.uploadResource(image, charmName, name);
+                    if (exitCode !== 0) {
+                        throw new Error(`Could not upload resource with error ${stderr}`);
+                    }
+                    const { revision } = JSON.parse(stdout);
+                    const flag = `--resource=${name}:${revision}`;
+                    const info = `    -  ${name}: ${image}\n` +
+                        `       resource-revision: ${revision}\n`;
+                    flags.push(flag);
+                    resourceInfo += info;
                 }
-                const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
-                if (!resourceFlag)
-                    return;
-                flags.push(resourceFlag.flag);
-                resourceInfo += resourceFlag.info;
+                else {
+                    const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
+                    if (!resourceFlag)
+                        return;
+                    flags.push(resourceFlag.flag);
+                    resourceInfo += resourceFlag.info;
+                }
             })));
             return { flags, resourceInfo };
         });
@@ -43028,13 +43039,15 @@ class Charmcraft {
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
-                '--quiet',
+                '--format',
+                'json',
                 name,
                 resource_name,
                 '--image',
                 resourceDigest,
             ];
-            yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
+            const execOutput = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
+            return execOutput;
         });
     }
     buildResourceFlag(charmName, name, image) {

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42828,13 +42828,24 @@ class Charmcraft {
                 .filter(([name]) => !overrides || !Object.keys(overrides).includes(name))
                 .map(([name, image]) => __awaiter(this, void 0, void 0, function* () {
                 if (this.uploadImage) {
-                    yield this.uploadResource(image, charmName, name);
+                    const { exitCode, stdout, stderr } = yield this.uploadResource(image, charmName, name);
+                    if (exitCode !== 0) {
+                        throw new Error(`Could not upload resource with error ${stderr}`);
+                    }
+                    const { revision } = JSON.parse(stdout);
+                    const flag = `--resource=${name}:${revision}`;
+                    const info = `    -  ${name}: ${image}\n` +
+                        `       resource-revision: ${revision}\n`;
+                    flags.push(flag);
+                    resourceInfo += info;
                 }
-                const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
-                if (!resourceFlag)
-                    return;
-                flags.push(resourceFlag.flag);
-                resourceInfo += resourceFlag.info;
+                else {
+                    const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
+                    if (!resourceFlag)
+                        return;
+                    flags.push(resourceFlag.flag);
+                    resourceInfo += resourceFlag.info;
+                }
             })));
             return { flags, resourceInfo };
         });
@@ -42876,13 +42887,15 @@ class Charmcraft {
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
-                '--quiet',
+                '--format',
+                'json',
                 name,
                 resource_name,
                 '--image',
                 resourceDigest,
             ];
-            yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
+            const execOutput = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
+            return execOutput;
         });
     }
     buildResourceFlag(charmName, name, image) {

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42868,13 +42868,24 @@ class Charmcraft {
                 .filter(([name]) => !overrides || !Object.keys(overrides).includes(name))
                 .map(([name, image]) => __awaiter(this, void 0, void 0, function* () {
                 if (this.uploadImage) {
-                    yield this.uploadResource(image, charmName, name);
+                    const { exitCode, stdout, stderr } = yield this.uploadResource(image, charmName, name);
+                    if (exitCode !== 0) {
+                        throw new Error(`Could not upload resource with error ${stderr}`);
+                    }
+                    const { revision } = JSON.parse(stdout);
+                    const flag = `--resource=${name}:${revision}`;
+                    const info = `    -  ${name}: ${image}\n` +
+                        `       resource-revision: ${revision}\n`;
+                    flags.push(flag);
+                    resourceInfo += info;
                 }
-                const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
-                if (!resourceFlag)
-                    return;
-                flags.push(resourceFlag.flag);
-                resourceInfo += resourceFlag.info;
+                else {
+                    const resourceFlag = yield this.buildResourceFlag(charmName, name, image);
+                    if (!resourceFlag)
+                        return;
+                    flags.push(resourceFlag.flag);
+                    resourceInfo += resourceFlag.info;
+                }
             })));
             return { flags, resourceInfo };
         });
@@ -42916,13 +42927,15 @@ class Charmcraft {
             const resourceDigest = yield (0, docker_1.getImageDigest)(resource_image);
             const args = [
                 'upload-resource',
-                '--quiet',
+                '--format',
+                'json',
                 name,
                 resource_name,
                 '--image',
                 resourceDigest,
             ];
-            yield (0, exec_1.exec)('charmcraft', args, this.execOptions);
+            const execOutput = yield (0, exec_1.getExecOutput)('charmcraft', args, this.execOptions);
+            return execOutput;
         });
     }
     buildResourceFlag(charmName, name, image) {

--- a/src/services/charmcraft/charmcraft.test.ts
+++ b/src/services/charmcraft/charmcraft.test.ts
@@ -135,13 +135,15 @@ describe('the charmcraft service', () => {
           const digest = `somedigest`;
           const charmcraft = new Charmcraft('token', true);
 
-          const mockedExec = jest.spyOn(exec, 'exec').mockResolvedValue(0);
+          jest.spyOn(exec, 'exec').mockResolvedValue(0);
 
-          jest.spyOn(exec, 'getExecOutput').mockResolvedValue({
-            exitCode: 0,
-            stderr: '',
-            stdout: digest,
-          });
+          const mockedExec = jest
+            .spyOn(exec, 'getExecOutput')
+            .mockResolvedValue({
+              exitCode: 0,
+              stderr: '',
+              stdout: digest,
+            });
 
           await charmcraft.uploadResource(
             'placeholder-image',

--- a/upload-charm/README.md
+++ b/upload-charm/README.md
@@ -17,8 +17,9 @@ This action is used to upload a charm to charmhub.io.
 
 ### OCI Image
 
-When uploading a charm with OCI image resources, a new revision of the OCI image will be published
-and attached to the release. It is possible to disable this behavior using either `upload-image: false`
+When uploading a charm with OCI image resources, the action will try to upload the OCI image to Charmhub
+and attach it to the release. If the image already exists in Charmhub, then it will use an existing revision
+corresponding to that image. It is possible to disable this behavior using either `upload-image: false`
 or by providing `resource-overrides` pointing at a specific existing revision.
 
 ### Files


### PR DESCRIPTION
Use resource revision number returned by upload-resource command when uploading a charm with resources. This replaces the previous behaviour when the action was listing resources and was using the latest available.

The issue below documents why we need this change and why this change works. In short, the root cause is that Charmhub changed its behavior at some point and running `charmcraft upload-resource` does **not** create a new resource revision, breaking essentially the action which previously ran `charmcraft upload-resource` followed by `charmcraft  resource-revisions` and was attaching the latest available to the charm.

Here's an [example run](https://github.com/canonical/envoy-operator/actions/runs/9870973910/job/27257881279?pr=115#step:5:145) using the action from the PR's branch.

Closes #139
Ref canonical/bundle-kubeflow#962

Note that this PR does **not** touch the action's behavior where `upload-image` is set to `False`, given that this is a different use-case and its behavior wasn't altered by the aforementioned Charmhub change (it was just using the `latest` resource revision number available without uploading anything). We contacted however the people using it ([operator-workflows repo](https://github.com/canonical/operator-workflows/blob/main/.github/workflows/publish_charm.yaml#L101) ) to give them a heads up of the change. 