### PR TITLE
fix(upload-bundle): Implement the same functionality without using `juju-bundle`

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42604,29 +42604,6 @@ __exportStar(__nccwpck_require__(6366), exports);
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42638,31 +42615,24 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Bundle = void 0;
-const core = __importStar(__nccwpck_require__(2186));
-const exec = __importStar(__nccwpck_require__(1514));
+const core_1 = __nccwpck_require__(2186);
+const exec_1 = __nccwpck_require__(1514);
 class Bundle {
     publish(path, channel) {
         return __awaiter(this, void 0, void 0, function* () {
-            core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
+            (0, core_1.exportVariable)('CHARMCRAFT_AUTH', (0, core_1.getInput)('credentials'));
             process.chdir(path);
-            const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            if (result.exitCode === 0) {
-                const lastLine = result.stderr.trim().split('\n').pop();
-                if (lastLine) {
-                    const bundleName = lastLine.split(' ')[1];
-                    yield exec.exec('charmcraft', [
-                        'upload',
-                        bundleName,
-                        '--release',
-                        channel,
-                    ]);
-                }
-                else {
-                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
-                }
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['pack']);
+            if (result.exitCode !== 0) {
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+            }
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
             }
             else {
-                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+                throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
         });
     }

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42645,13 +42645,9 @@ class Bundle {
         return __awaiter(this, void 0, void 0, function* () {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
-            yield exec.exec('juju-bundle', [
-                'publish',
-                '--destructive-mode',
-                '--serial',
-                '--release',
-                channel,
-            ]);
+            const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            const bundleName = result.stdout.split(' ')[1].trim();
+            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42646,19 +42646,23 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            core.info(result.stdout);
-            const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield exec.exec('charmcraft', [
-                    'upload',
-                    bundleName,
-                    '--release',
-                    channel,
-                ]);
+            if (result.exitCode === 0) {
+                const lastLine = result.stderr.trim().split('\n').pop();
+                if (lastLine) {
+                    const bundleName = lastLine.split(' ')[1];
+                    yield exec.exec('charmcraft', [
+                        'upload',
+                        bundleName,
+                        '--release',
+                        channel,
+                    ]);
+                }
+                else {
+                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
+                }
             }
             else {
-                throw new Error('charmcraft pack ran unsuccessfully');
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
         });
     }

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42627,13 +42627,11 @@ class Bundle {
                 throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
             const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
-            }
-            else {
+            if (!lastLine) {
                 throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
+            const bundleName = lastLine.split(' ')[1];
+            yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42647,8 +42647,19 @@ class Bundle {
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
             core.info(result.stdout);
-            const bundleName = result.stdout.split(' ')[1].trim();
-            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield exec.exec('charmcraft', [
+                    'upload',
+                    bundleName,
+                    '--release',
+                    channel,
+                ]);
+            }
+            else {
+                throw new Error('charmcraft pack ran unsuccessfully');
+            }
         });
     }
 }

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42646,6 +42646,7 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            core.info(result.stdout);
             const bundleName = result.stdout.split(' ')[1].trim();
             yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -42841,19 +42841,23 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            core.info(result.stdout);
-            const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield exec.exec('charmcraft', [
-                    'upload',
-                    bundleName,
-                    '--release',
-                    channel,
-                ]);
+            if (result.exitCode === 0) {
+                const lastLine = result.stderr.trim().split('\n').pop();
+                if (lastLine) {
+                    const bundleName = lastLine.split(' ')[1];
+                    yield exec.exec('charmcraft', [
+                        'upload',
+                        bundleName,
+                        '--release',
+                        channel,
+                    ]);
+                }
+                else {
+                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
+                }
             }
             else {
-                throw new Error('charmcraft pack ran unsuccessfully');
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
         });
     }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -42841,6 +42841,7 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            core.info(result.stdout);
             const bundleName = result.stdout.split(' ')[1].trim();
             yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -42842,8 +42842,19 @@ class Bundle {
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
             core.info(result.stdout);
-            const bundleName = result.stdout.split(' ')[1].trim();
-            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield exec.exec('charmcraft', [
+                    'upload',
+                    bundleName,
+                    '--release',
+                    channel,
+                ]);
+            }
+            else {
+                throw new Error('charmcraft pack ran unsuccessfully');
+            }
         });
     }
 }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -42840,13 +42840,9 @@ class Bundle {
         return __awaiter(this, void 0, void 0, function* () {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
-            yield exec.exec('juju-bundle', [
-                'publish',
-                '--destructive-mode',
-                '--serial',
-                '--release',
-                channel,
-            ]);
+            const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            const bundleName = result.stdout.split(' ')[1].trim();
+            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -42822,13 +42822,11 @@ class Bundle {
                 throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
             const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
-            }
-            else {
+            if (!lastLine) {
                 throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
+            const bundleName = lastLine.split(' ')[1];
+            yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -42799,29 +42799,6 @@ __exportStar(__nccwpck_require__(6366), exports);
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42833,31 +42810,24 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Bundle = void 0;
-const core = __importStar(__nccwpck_require__(2186));
-const exec = __importStar(__nccwpck_require__(1514));
+const core_1 = __nccwpck_require__(2186);
+const exec_1 = __nccwpck_require__(1514);
 class Bundle {
     publish(path, channel) {
         return __awaiter(this, void 0, void 0, function* () {
-            core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
+            (0, core_1.exportVariable)('CHARMCRAFT_AUTH', (0, core_1.getInput)('credentials'));
             process.chdir(path);
-            const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            if (result.exitCode === 0) {
-                const lastLine = result.stderr.trim().split('\n').pop();
-                if (lastLine) {
-                    const bundleName = lastLine.split(' ')[1];
-                    yield exec.exec('charmcraft', [
-                        'upload',
-                        bundleName,
-                        '--release',
-                        channel,
-                    ]);
-                }
-                else {
-                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
-                }
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['pack']);
+            if (result.exitCode !== 0) {
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+            }
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
             }
             else {
-                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+                throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
         });
     }

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42706,13 +42706,11 @@ class Bundle {
                 throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
             const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
-            }
-            else {
+            if (!lastLine) {
                 throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
+            const bundleName = lastLine.split(' ')[1];
+            yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42683,29 +42683,6 @@ __exportStar(__nccwpck_require__(6366), exports);
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42717,31 +42694,24 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Bundle = void 0;
-const core = __importStar(__nccwpck_require__(2186));
-const exec = __importStar(__nccwpck_require__(1514));
+const core_1 = __nccwpck_require__(2186);
+const exec_1 = __nccwpck_require__(1514);
 class Bundle {
     publish(path, channel) {
         return __awaiter(this, void 0, void 0, function* () {
-            core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
+            (0, core_1.exportVariable)('CHARMCRAFT_AUTH', (0, core_1.getInput)('credentials'));
             process.chdir(path);
-            const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            if (result.exitCode === 0) {
-                const lastLine = result.stderr.trim().split('\n').pop();
-                if (lastLine) {
-                    const bundleName = lastLine.split(' ')[1];
-                    yield exec.exec('charmcraft', [
-                        'upload',
-                        bundleName,
-                        '--release',
-                        channel,
-                    ]);
-                }
-                else {
-                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
-                }
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['pack']);
+            if (result.exitCode !== 0) {
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+            }
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
             }
             else {
-                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+                throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
         });
     }

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42724,13 +42724,9 @@ class Bundle {
         return __awaiter(this, void 0, void 0, function* () {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
-            yield exec.exec('juju-bundle', [
-                'publish',
-                '--destructive-mode',
-                '--serial',
-                '--release',
-                channel,
-            ]);
+            const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            const bundleName = result.stdout.split(' ')[1].trim();
+            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42725,6 +42725,7 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            core.info(result.stdout);
             const bundleName = result.stdout.split(' ')[1].trim();
             yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42725,19 +42725,23 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            core.info(result.stdout);
-            const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield exec.exec('charmcraft', [
-                    'upload',
-                    bundleName,
-                    '--release',
-                    channel,
-                ]);
+            if (result.exitCode === 0) {
+                const lastLine = result.stderr.trim().split('\n').pop();
+                if (lastLine) {
+                    const bundleName = lastLine.split(' ')[1];
+                    yield exec.exec('charmcraft', [
+                        'upload',
+                        bundleName,
+                        '--release',
+                        channel,
+                    ]);
+                }
+                else {
+                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
+                }
             }
             else {
-                throw new Error('charmcraft pack ran unsuccessfully');
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
         });
     }

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42726,8 +42726,19 @@ class Bundle {
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
             core.info(result.stdout);
-            const bundleName = result.stdout.split(' ')[1].trim();
-            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield exec.exec('charmcraft', [
+                    'upload',
+                    bundleName,
+                    '--release',
+                    channel,
+                ]);
+            }
+            else {
+                throw new Error('charmcraft pack ran unsuccessfully');
+            }
         });
     }
 }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42737,19 +42737,23 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            core.info(result.stdout);
-            const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield exec.exec('charmcraft', [
-                    'upload',
-                    bundleName,
-                    '--release',
-                    channel,
-                ]);
+            if (result.exitCode === 0) {
+                const lastLine = result.stderr.trim().split('\n').pop();
+                if (lastLine) {
+                    const bundleName = lastLine.split(' ')[1];
+                    yield exec.exec('charmcraft', [
+                        'upload',
+                        bundleName,
+                        '--release',
+                        channel,
+                    ]);
+                }
+                else {
+                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
+                }
             }
             else {
-                throw new Error('charmcraft pack ran unsuccessfully');
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
         });
     }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42695,29 +42695,6 @@ __exportStar(__nccwpck_require__(6366), exports);
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42729,31 +42706,24 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Bundle = void 0;
-const core = __importStar(__nccwpck_require__(2186));
-const exec = __importStar(__nccwpck_require__(1514));
+const core_1 = __nccwpck_require__(2186);
+const exec_1 = __nccwpck_require__(1514);
 class Bundle {
     publish(path, channel) {
         return __awaiter(this, void 0, void 0, function* () {
-            core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
+            (0, core_1.exportVariable)('CHARMCRAFT_AUTH', (0, core_1.getInput)('credentials'));
             process.chdir(path);
-            const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            if (result.exitCode === 0) {
-                const lastLine = result.stderr.trim().split('\n').pop();
-                if (lastLine) {
-                    const bundleName = lastLine.split(' ')[1];
-                    yield exec.exec('charmcraft', [
-                        'upload',
-                        bundleName,
-                        '--release',
-                        channel,
-                    ]);
-                }
-                else {
-                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
-                }
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['pack']);
+            if (result.exitCode !== 0) {
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+            }
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
             }
             else {
-                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+                throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
         });
     }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42736,13 +42736,9 @@ class Bundle {
         return __awaiter(this, void 0, void 0, function* () {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
-            yield exec.exec('juju-bundle', [
-                'publish',
-                '--destructive-mode',
-                '--serial',
-                '--release',
-                channel,
-            ]);
+            const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            const bundleName = result.stdout.split(' ')[1].trim();
+            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42737,6 +42737,7 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            core.info(result.stdout);
             const bundleName = result.stdout.split(' ')[1].trim();
             yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42718,13 +42718,11 @@ class Bundle {
                 throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
             const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
-            }
-            else {
+            if (!lastLine) {
                 throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
+            const bundleName = lastLine.split(' ')[1];
+            yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42738,8 +42738,19 @@ class Bundle {
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
             core.info(result.stdout);
-            const bundleName = result.stdout.split(' ')[1].trim();
-            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield exec.exec('charmcraft', [
+                    'upload',
+                    bundleName,
+                    '--release',
+                    channel,
+                ]);
+            }
+            else {
+                throw new Error('charmcraft pack ran unsuccessfully');
+            }
         });
     }
 }

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -42826,29 +42826,6 @@ __exportStar(__nccwpck_require__(6366), exports);
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42860,31 +42837,24 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Bundle = void 0;
-const core = __importStar(__nccwpck_require__(2186));
-const exec = __importStar(__nccwpck_require__(1514));
+const core_1 = __nccwpck_require__(2186);
+const exec_1 = __nccwpck_require__(1514);
 class Bundle {
     publish(path, channel) {
         return __awaiter(this, void 0, void 0, function* () {
-            core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
+            (0, core_1.exportVariable)('CHARMCRAFT_AUTH', (0, core_1.getInput)('credentials'));
             process.chdir(path);
-            const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            if (result.exitCode === 0) {
-                const lastLine = result.stderr.trim().split('\n').pop();
-                if (lastLine) {
-                    const bundleName = lastLine.split(' ')[1];
-                    yield exec.exec('charmcraft', [
-                        'upload',
-                        bundleName,
-                        '--release',
-                        channel,
-                    ]);
-                }
-                else {
-                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
-                }
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['pack']);
+            if (result.exitCode !== 0) {
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+            }
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
             }
             else {
-                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+                throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
         });
     }

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -42867,13 +42867,9 @@ class Bundle {
         return __awaiter(this, void 0, void 0, function* () {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
-            yield exec.exec('juju-bundle', [
-                'publish',
-                '--destructive-mode',
-                '--serial',
-                '--release',
-                channel,
-            ]);
+            const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            const bundleName = result.stdout.split(' ')[1].trim();
+            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -42868,6 +42868,7 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            core.info(result.stdout);
             const bundleName = result.stdout.split(' ')[1].trim();
             yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -42849,13 +42849,11 @@ class Bundle {
                 throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
             const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
-            }
-            else {
+            if (!lastLine) {
                 throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
+            const bundleName = lastLine.split(' ')[1];
+            yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -42868,19 +42868,23 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            core.info(result.stdout);
-            const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield exec.exec('charmcraft', [
-                    'upload',
-                    bundleName,
-                    '--release',
-                    channel,
-                ]);
+            if (result.exitCode === 0) {
+                const lastLine = result.stderr.trim().split('\n').pop();
+                if (lastLine) {
+                    const bundleName = lastLine.split(' ')[1];
+                    yield exec.exec('charmcraft', [
+                        'upload',
+                        bundleName,
+                        '--release',
+                        channel,
+                    ]);
+                }
+                else {
+                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
+                }
             }
             else {
-                throw new Error('charmcraft pack ran unsuccessfully');
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
         });
     }

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -42869,8 +42869,19 @@ class Bundle {
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
             core.info(result.stdout);
-            const bundleName = result.stdout.split(' ')[1].trim();
-            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield exec.exec('charmcraft', [
+                    'upload',
+                    bundleName,
+                    '--release',
+                    channel,
+                ]);
+            }
+            else {
+                throw new Error('charmcraft pack ran unsuccessfully');
+            }
         });
     }
 }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42716,19 +42716,23 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            core.info(result.stdout);
-            const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield exec.exec('charmcraft', [
-                    'upload',
-                    bundleName,
-                    '--release',
-                    channel,
-                ]);
+            if (result.exitCode === 0) {
+                const lastLine = result.stderr.trim().split('\n').pop();
+                if (lastLine) {
+                    const bundleName = lastLine.split(' ')[1];
+                    yield exec.exec('charmcraft', [
+                        'upload',
+                        bundleName,
+                        '--release',
+                        channel,
+                    ]);
+                }
+                else {
+                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
+                }
             }
             else {
-                throw new Error('charmcraft pack ran unsuccessfully');
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
         });
     }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42717,8 +42717,19 @@ class Bundle {
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
             core.info(result.stdout);
-            const bundleName = result.stdout.split(' ')[1].trim();
-            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield exec.exec('charmcraft', [
+                    'upload',
+                    bundleName,
+                    '--release',
+                    channel,
+                ]);
+            }
+            else {
+                throw new Error('charmcraft pack ran unsuccessfully');
+            }
         });
     }
 }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42716,6 +42716,7 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            core.info(result.stdout);
             const bundleName = result.stdout.split(' ')[1].trim();
             yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42674,29 +42674,6 @@ __exportStar(__nccwpck_require__(6366), exports);
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42708,31 +42685,24 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Bundle = void 0;
-const core = __importStar(__nccwpck_require__(2186));
-const exec = __importStar(__nccwpck_require__(1514));
+const core_1 = __nccwpck_require__(2186);
+const exec_1 = __nccwpck_require__(1514);
 class Bundle {
     publish(path, channel) {
         return __awaiter(this, void 0, void 0, function* () {
-            core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
+            (0, core_1.exportVariable)('CHARMCRAFT_AUTH', (0, core_1.getInput)('credentials'));
             process.chdir(path);
-            const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            if (result.exitCode === 0) {
-                const lastLine = result.stderr.trim().split('\n').pop();
-                if (lastLine) {
-                    const bundleName = lastLine.split(' ')[1];
-                    yield exec.exec('charmcraft', [
-                        'upload',
-                        bundleName,
-                        '--release',
-                        channel,
-                    ]);
-                }
-                else {
-                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
-                }
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['pack']);
+            if (result.exitCode !== 0) {
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+            }
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
             }
             else {
-                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+                throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
         });
     }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42697,13 +42697,11 @@ class Bundle {
                 throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
             const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
-            }
-            else {
+            if (!lastLine) {
                 throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
+            const bundleName = lastLine.split(' ')[1];
+            yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42715,13 +42715,9 @@ class Bundle {
         return __awaiter(this, void 0, void 0, function* () {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
-            yield exec.exec('juju-bundle', [
-                'publish',
-                '--destructive-mode',
-                '--serial',
-                '--release',
-                channel,
-            ]);
+            const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            const bundleName = result.stdout.split(' ')[1].trim();
+            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42756,6 +42756,7 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            core.info(result.stdout);
             const bundleName = result.stdout.split(' ')[1].trim();
             yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42756,19 +42756,23 @@ class Bundle {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            core.info(result.stdout);
-            const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield exec.exec('charmcraft', [
-                    'upload',
-                    bundleName,
-                    '--release',
-                    channel,
-                ]);
+            if (result.exitCode === 0) {
+                const lastLine = result.stderr.trim().split('\n').pop();
+                if (lastLine) {
+                    const bundleName = lastLine.split(' ')[1];
+                    yield exec.exec('charmcraft', [
+                        'upload',
+                        bundleName,
+                        '--release',
+                        channel,
+                    ]);
+                }
+                else {
+                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
+                }
             }
             else {
-                throw new Error('charmcraft pack ran unsuccessfully');
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
         });
     }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42755,13 +42755,9 @@ class Bundle {
         return __awaiter(this, void 0, void 0, function* () {
             core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
             process.chdir(path);
-            yield exec.exec('juju-bundle', [
-                'publish',
-                '--destructive-mode',
-                '--serial',
-                '--release',
-                channel,
-            ]);
+            const result = yield exec.getExecOutput('charmcraft', ['pack']);
+            const bundleName = result.stdout.split(' ')[1].trim();
+            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42757,8 +42757,19 @@ class Bundle {
             process.chdir(path);
             const result = yield exec.getExecOutput('charmcraft', ['pack']);
             core.info(result.stdout);
-            const bundleName = result.stdout.split(' ')[1].trim();
-            yield exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield exec.exec('charmcraft', [
+                    'upload',
+                    bundleName,
+                    '--release',
+                    channel,
+                ]);
+            }
+            else {
+                throw new Error('charmcraft pack ran unsuccessfully');
+            }
         });
     }
 }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42737,13 +42737,11 @@ class Bundle {
                 throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
             }
             const lastLine = result.stderr.trim().split('\n').pop();
-            if (lastLine) {
-                const bundleName = lastLine.split(' ')[1];
-                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
-            }
-            else {
+            if (!lastLine) {
                 throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
+            const bundleName = lastLine.split(' ')[1];
+            yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
         });
     }
 }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42714,29 +42714,6 @@ __exportStar(__nccwpck_require__(6366), exports);
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42748,31 +42725,24 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Bundle = void 0;
-const core = __importStar(__nccwpck_require__(2186));
-const exec = __importStar(__nccwpck_require__(1514));
+const core_1 = __nccwpck_require__(2186);
+const exec_1 = __nccwpck_require__(1514);
 class Bundle {
     publish(path, channel) {
         return __awaiter(this, void 0, void 0, function* () {
-            core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
+            (0, core_1.exportVariable)('CHARMCRAFT_AUTH', (0, core_1.getInput)('credentials'));
             process.chdir(path);
-            const result = yield exec.getExecOutput('charmcraft', ['pack']);
-            if (result.exitCode === 0) {
-                const lastLine = result.stderr.trim().split('\n').pop();
-                if (lastLine) {
-                    const bundleName = lastLine.split(' ')[1];
-                    yield exec.exec('charmcraft', [
-                        'upload',
-                        bundleName,
-                        '--release',
-                        channel,
-                    ]);
-                }
-                else {
-                    throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
-                }
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['pack']);
+            if (result.exitCode !== 0) {
+                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+            }
+            const lastLine = result.stderr.trim().split('\n').pop();
+            if (lastLine) {
+                const bundleName = lastLine.split(' ')[1];
+                yield (0, exec_1.exec)('charmcraft', ['upload', bundleName, '--release', channel]);
             }
             else {
-                throw new Error(`charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`);
+                throw new Error('Failed to extract the bundle name from the output of charmcraft pack.');
             }
         });
     }

--- a/src/services/bundle/bundle.ts
+++ b/src/services/bundle/bundle.ts
@@ -13,14 +13,13 @@ class Bundle {
       );
     }
     const lastLine = result.stderr.trim().split('\n').pop();
-    if (lastLine) {
-      const bundleName = lastLine.split(' ')[1];
-      await exec('charmcraft', ['upload', bundleName, '--release', channel]);
-    } else {
+    if (!lastLine) {
       throw new Error(
         'Failed to extract the bundle name from the output of charmcraft pack.',
       );
     }
+    const bundleName = lastLine.split(' ')[1];
+    await exec('charmcraft', ['upload', bundleName, '--release', channel]);
   }
 }
 

--- a/src/services/bundle/bundle.ts
+++ b/src/services/bundle/bundle.ts
@@ -7,6 +7,7 @@ class Bundle {
     process.chdir(path);
 
     const result = await exec.getExecOutput('charmcraft', ['pack']);
+    core.info(result.stdout);
     const bundleName = result.stdout.split(' ')[1].trim();
 
     await exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);

--- a/src/services/bundle/bundle.ts
+++ b/src/services/bundle/bundle.ts
@@ -1,30 +1,24 @@
-import * as core from '@actions/core';
-import * as exec from '@actions/exec';
+import { exportVariable, getInput } from '@actions/core';
+import { exec, getExecOutput } from '@actions/exec';
 
 class Bundle {
   async publish(path: string, channel: string) {
-    core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
+    exportVariable('CHARMCRAFT_AUTH', getInput('credentials'));
     process.chdir(path);
 
-    const result = await exec.getExecOutput('charmcraft', ['pack']);
-    if (result.exitCode === 0) {
-      const lastLine = result.stderr.trim().split('\n').pop();
-      if (lastLine) {
-        const bundleName = lastLine.split(' ')[1];
-        await exec.exec('charmcraft', [
-          'upload',
-          bundleName,
-          '--release',
-          channel,
-        ]);
-      } else {
-        throw new Error(
-          'Failed to extract the bundle name from the output of charmcraft pack.',
-        );
-      }
-    } else {
+    const result = await getExecOutput('charmcraft', ['pack']);
+    if (result.exitCode !== 0) {
       throw new Error(
         `charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`,
+      );
+    }
+    const lastLine = result.stderr.trim().split('\n').pop();
+    if (lastLine) {
+      const bundleName = lastLine.split(' ')[1];
+      await exec('charmcraft', ['upload', bundleName, '--release', channel]);
+    } else {
+      throw new Error(
+        'Failed to extract the bundle name from the output of charmcraft pack.',
       );
     }
   }

--- a/src/services/bundle/bundle.ts
+++ b/src/services/bundle/bundle.ts
@@ -7,19 +7,25 @@ class Bundle {
     process.chdir(path);
 
     const result = await exec.getExecOutput('charmcraft', ['pack']);
-    core.info(result.stdout);
-    const lastLine = result.stderr.trim().split('\n').pop();
-
-    if (lastLine) {
-      const bundleName = lastLine.split(' ')[1];
-      await exec.exec('charmcraft', [
-        'upload',
-        bundleName,
-        '--release',
-        channel,
-      ]);
+    if (result.exitCode === 0) {
+      const lastLine = result.stderr.trim().split('\n').pop();
+      if (lastLine) {
+        const bundleName = lastLine.split(' ')[1];
+        await exec.exec('charmcraft', [
+          'upload',
+          bundleName,
+          '--release',
+          channel,
+        ]);
+      } else {
+        throw new Error(
+          'Failed to extract the bundle name from the output of charmcraft pack.',
+        );
+      }
     } else {
-      throw new Error('charmcraft pack ran unsuccessfully');
+      throw new Error(
+        `charmcraft pack ran unsuccessfully with exit code ${result.exitCode}.`,
+      );
     }
   }
 }

--- a/src/services/bundle/bundle.ts
+++ b/src/services/bundle/bundle.ts
@@ -8,9 +8,19 @@ class Bundle {
 
     const result = await exec.getExecOutput('charmcraft', ['pack']);
     core.info(result.stdout);
-    const bundleName = result.stdout.split(' ')[1].trim();
+    const lastLine = result.stderr.trim().split('\n').pop();
 
-    await exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
+    if (lastLine) {
+      const bundleName = lastLine.split(' ')[1];
+      await exec.exec('charmcraft', [
+        'upload',
+        bundleName,
+        '--release',
+        channel,
+      ]);
+    } else {
+      throw new Error('charmcraft pack ran unsuccessfully');
+    }
   }
 }
 

--- a/src/services/bundle/bundle.ts
+++ b/src/services/bundle/bundle.ts
@@ -5,13 +5,11 @@ class Bundle {
   async publish(path: string, channel: string) {
     core.exportVariable('CHARMCRAFT_AUTH', core.getInput('credentials'));
     process.chdir(path);
-    await exec.exec('juju-bundle', [
-      'publish',
-      '--destructive-mode',
-      '--serial',
-      '--release',
-      channel,
-    ]);
+
+    const result = await exec.getExecOutput('charmcraft', ['pack']);
+    const bundleName = result.stdout.split(' ')[1].trim();
+
+    await exec.exec('charmcraft', ['upload', bundleName, '--release', channel]);
   }
 }
 


### PR DESCRIPTION
Closes #23 and #150.

This PR updates the `upload-bundle` action to decouple from the `juju-bundle` executable, found [here](https://github.com/canonical/juju-bundle). 

Essentially, the action now calls `charmcraft pack` on the bundle.yaml file's directory, captures the output to get the filename of the `.zip` bundle file, and then calls `charmcraft upload` for the appropriate channel and using the credentials in `$CHARMCRAFT_AUTH`.

Note that for some reason, all the output in the `charmcraft pack` executable is always on stderr, and not on stdout.

Here is an [example run](https://github.com/canonical/bundle-kubeflow/actions/runs/10578537130) using the action here.