### PR TITLE
Update dump-logs README.md

### DIFF
--- a/dump-logs/README.md
+++ b/dump-logs/README.md
@@ -21,7 +21,7 @@ jobs:
       - name: Set up and run some tests
       - name: Dump logs
         if: failure()
-        uses: canonical/charming-actions/dump-logs
+        uses: canonical/charming-actions/dump-logs@2.6.3
 ```
 
 ## Known issues


### PR DESCRIPTION
Update README.md to provide a more accurate example. Using without a tag results in the following error
```
the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```
which can be a pain to debug, since the error doesn't indicate which part of the workflow it comes from (see example below)
```
---> "./.github/workflows/terraform-apply.yaml" (source branch with sha:4d31459a9d9ded130eceb2c50d3cc72a634cbbe5)
: the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```