### PR TITLE
fix: exclude legacy `all` architecture in base processing

### DIFF
--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42519,7 +42519,10 @@ class PromoteCharmAction {
     }
     getRevisions(name, track, channel, bases) {
         return __awaiter(this, void 0, void 0, function* () {
-            return Promise.all(bases.map((base) => __awaiter(this, void 0, void 0, function* () {
+            // Filter out bases with architecture "all"
+            const filteredBases = bases.filter((base) => base.architecture !== 'all');
+            // Map filtered bases to their revision information
+            return Promise.all(filteredBases.map((base) => __awaiter(this, void 0, void 0, function* () {
                 return this.charmcraft.getRevisionInfoFromChannelJson(name, track, channel, base);
             })));
         });

--- a/src/actions/promote-charm/promote-charm.ts
+++ b/src/actions/promote-charm/promote-charm.ts
@@ -32,8 +32,12 @@ export class PromoteCharmAction {
     channel: string,
     bases: Base[],
   ): Promise<RevisionResourceInfo[]> {
+    // Filter out bases with architecture "all"
+    const filteredBases = bases.filter((base) => base.architecture !== 'all');
+
+    // Map filtered bases to their revision information
     return Promise.all(
-      bases.map(async (base: Base) =>
+      filteredBases.map(async (base: Base) =>
         this.charmcraft.getRevisionInfoFromChannelJson(
           name,
           track,


### PR DESCRIPTION
Ensure that the legacy `all` architecture is ignored during promotion to avoid processing legacy or unsupported configurations. This resolves issues with handling bases that use the `all` architecture.

In the case of legacy charms like [sysconfig](https://github.com/canonical/charm-sysconfig), the output of `charmcraft status sysconfig --format json` includes the legacy `all` architecture. Channels associated with this architecture are not `open`, making it impossible to release revisions to them.

To address this issue, this change ensures that the `all` architecture is ignored during the promotion process, preventing unnecessary processing of legacy configurations and ensuring compatibility with modern workflows.

```
[
    {
        "track": "latest",
        "mappings": [
            {
                "base": {
                    "name": "ubuntu",
                    "channel": "16.04",
                    "architecture": "all"
                },
                "releases": [
                    {
                        "status": "open",
                        "channel": "latest/stable",
                        "version": "6",
                        "revision": 6,
                        "resources": [],
                        "expires_at": null
                    },
                    {
                        "status": "open",
                        "channel": "latest/candidate",
                        "version": "6",
                        "revision": 6,
                        "resources": [],
                        "expires_at": null
                    },
                    {
                        "status": "tracking",
                        "channel": "latest/beta",
                        "version": null,
                        "revision": null,
                        "resources": null,
                        "expires_at": null
                    },
                    {
                        "status": "tracking",
                        "channel": "latest/edge",
                        "version": null,
                        "revision": null,
                        "resources": null,
                        "expires_at": null
                    }
                ]
            },
``` 