### PR TITLE
feat: support multiple built-charm-path

### DIFF
--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42541,7 +42541,7 @@ class UploadCharmAction {
                 yield this.snap.install('charmcraft', this.charmcraftChannel);
                 process.chdir(this.charmPath);
                 const charms = this.builtCharmPath
-                    ? [this.builtCharmPath]
+                    ? this.builtCharmPath.split(',').map((path) => path.trim())
                     : yield this.charmcraft.pack(this.destructive);
                 const overrides = this.overrides;
                 const imageResults = yield this.charmcraft.uploadResources(overrides);

--- a/src/actions/upload-charm/upload-charm.ts
+++ b/src/actions/upload-charm/upload-charm.ts
@@ -57,7 +57,7 @@ export class UploadCharmAction {
       process.chdir(this.charmPath!);
 
       const charms = this.builtCharmPath
-        ? [this.builtCharmPath]
+        ? this.builtCharmPath.split(',').map((path) => path.trim())
         : await this.charmcraft.pack(this.destructive);
 
       const overrides = this.overrides!;

--- a/upload-charm/README.md
+++ b/upload-charm/README.md
@@ -34,7 +34,7 @@ If you want to use a new resource, you'll have to cut a new resource revision **
 | Key                  | Description                                                                                                      | Required |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- |
 | `charm-path`         | Path to the charm we want to publish. Defaults to the current working directory.                                 |          |
-| `built-charm-path`   | Path to a pre-built charm we want to publish.                                                                    |          |
+| `built-charm-path`   | Path to one or more pre-built charms as comma-separated values.                                                  |          |
 | `channel`            | Channel on charmhub to publish the charm in. Defaults to `latest/edge`.                                          |          |
 | `credentials`        | Credentials [exported](https://juju.is/docs/sdk/remote-env-auth) using `charmcraft login --export`.              | ✔️       |
 | `destructive-mode`   | Whether or not to pack using destructive mode. Defaults to `true`.                                               |          |

--- a/upload-charm/action.yaml
+++ b/upload-charm/action.yaml
@@ -26,7 +26,10 @@ inputs:
   built-charm-path:
     required: false
     description: |
-      Path to a pre-built charm.
+      Path to one or more pre-built charms as comma-separated values.
+      If provided, charmcraft pack will not be executed.
+      - Single charm: `/tmp/build/my-charm.charm`
+      - Multiple charms: `/tmp/build/my-charm.charm,/tmp/build/my-charm_amd64.charm`
   charmcraft-channel:
     required: false
     default: 'latest/stable'


### PR DESCRIPTION
## Overview
Support multiple pre-built charm paths in the `upload-charm` action.
## Rationale
Some charmcraft files could generate multiple charm files. This pull request modifies the `built-charm-path` property to support multiple charm files separated by commas while keeping the compatibility with a single path.

---
### External Links
- Failing `upload-charms` job: https://github.com/canonical/k8s-operator/actions/runs/13021862096/job/36324029496
