### PR TITLE
Supress auto-logging from getting the json status

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42817,7 +42817,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -42920,7 +42920,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -43012,7 +43012,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43115,7 +43115,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42899,7 +42899,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43002,7 +43002,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42908,7 +42908,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43011,7 +43011,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -43039,7 +43039,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43142,7 +43142,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42887,7 +42887,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -42990,7 +42990,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42927,7 +42927,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43030,7 +43030,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -166,7 +166,7 @@ class Charmcraft {
       Revision    Created at    Size
       2 <- This   2022-01-20    1024B
       1           2021-07-19    512B
-      
+
     */
 
     if (result.stdout.trim().split('\n').length <= 1) {
@@ -289,7 +289,7 @@ class Charmcraft {
     const result = await getExecOutput(
       'charmcraft',
       ['status', charm, '--format', 'json'],
-      this.execOptions,
+      { ...this.execOptions, silent: true }, // Suppress auto-logging
     );
     const parsedObj = JSON.parse(result.stdout);
     return parsedObj;


### PR DESCRIPTION
A project when run the promote workflow creates an overwhelming amount of logs that makes hard to understand what is happening. See this [example](https://github.com/canonical/charm-prometheus-libvirt-exporter/actions/runs/14221483738/job/39853639135) that generated `17,222` lines.

With this change the output is way lower and easier to understand the steps. See this [example](https://github.com/canonical/charm-prometheus-libvirt-exporter/actions/runs/14244621782/job/39922331459)