### PR TITLE
Ignore bases that doesn't have a target channel open

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42817,7 +42817,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43016,6 +43016,24 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             return charmcraftStatus[trackIndex].mappings.map((x) => x.base);
+        });
+    }
+    getOpenBases(charm, targetTrack, targetChannel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
+            }
+            const { mappings } = charmcraftStatus[trackIndex];
+            const validBases = mappings
+                .filter((mapping) => mapping.base &&
+                mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
+                    release.status === 'open'))
+                .map((mapping) => mapping.base);
+            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            return validBases;
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42920,7 +42920,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42920,7 +42920,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });
@@ -43027,12 +43027,20 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             const { mappings } = charmcraftStatus[trackIndex];
+            const allBases = mappings.map((mapping) => mapping.base);
             const validBases = mappings
                 .filter((mapping) => mapping.base &&
                 mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
                     release.status === 'open'))
                 .map((mapping) => mapping.base);
-            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            // Determine bases that were filtered out
+            const filteredOutBases = allBases.filter((base) => !validBases.some((validBase) => validBase.name === base.name &&
+                validBase.channel === base.channel &&
+                validBase.architecture === base.architecture));
+            if (filteredOutBases.length > 0) {
+                core.warning(`Filtered out bases that are not open for ${targetTrack}/${targetChannel}: ${JSON.stringify(filteredOutBases, null, 2)}`);
+            }
+            core.info(`Filtered bases that are open for ${targetTrack}/${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
             return validBases;
         });
     }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -43115,7 +43115,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });
@@ -43222,12 +43222,20 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             const { mappings } = charmcraftStatus[trackIndex];
+            const allBases = mappings.map((mapping) => mapping.base);
             const validBases = mappings
                 .filter((mapping) => mapping.base &&
                 mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
                     release.status === 'open'))
                 .map((mapping) => mapping.base);
-            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            // Determine bases that were filtered out
+            const filteredOutBases = allBases.filter((base) => !validBases.some((validBase) => validBase.name === base.name &&
+                validBase.channel === base.channel &&
+                validBase.architecture === base.architecture));
+            if (filteredOutBases.length > 0) {
+                core.warning(`Filtered out bases that are not open for ${targetTrack}/${targetChannel}: ${JSON.stringify(filteredOutBases, null, 2)}`);
+            }
+            core.info(`Filtered bases that are open for ${targetTrack}/${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
             return validBases;
         });
     }

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -43115,7 +43115,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -43012,7 +43012,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43211,6 +43211,24 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             return charmcraftStatus[trackIndex].mappings.map((x) => x.base);
+        });
+    }
+    getOpenBases(charm, targetTrack, targetChannel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
+            }
+            const { mappings } = charmcraftStatus[trackIndex];
+            const validBases = mappings
+                .filter((mapping) => mapping.base &&
+                mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
+                    release.status === 'open'))
+                .map((mapping) => mapping.base);
+            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            return validBases;
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42999,7 +42999,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42519,10 +42519,7 @@ class PromoteCharmAction {
     }
     getRevisions(name, track, channel, bases) {
         return __awaiter(this, void 0, void 0, function* () {
-            // Filter out bases with architecture "all"
-            const filteredBases = bases.filter((base) => base.architecture !== 'all');
-            // Map filtered bases to their revision information
-            return Promise.all(filteredBases.map((base) => __awaiter(this, void 0, void 0, function* () {
+            return Promise.all(bases.map((base) => __awaiter(this, void 0, void 0, function* () {
                 return this.charmcraft.getRevisionInfoFromChannelJson(name, track, channel, base);
             })));
         });
@@ -42534,7 +42531,7 @@ class PromoteCharmAction {
                 process.chdir(this.charmPath);
                 const charmName = this.charmcraft.charmName();
                 const [originTrack, originChannel] = this.originChannel.split('/');
-                const basesArray = yield this.charmcraft.getBases(charmName, originTrack);
+                const basesArray = yield this.charmcraft.getOpenBases(charmName, originTrack, originChannel);
                 const revisions = yield this.getRevisions(charmName, originTrack, originChannel, basesArray);
                 yield Promise.all(revisions.map(({ charmRev, resources }) => __awaiter(this, void 0, void 0, function* () {
                     return this.charmcraft.release(charmName, charmRev, this.destinationChannel, resources);
@@ -42899,7 +42896,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43098,6 +43095,24 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             return charmcraftStatus[trackIndex].mappings.map((x) => x.base);
+        });
+    }
+    getOpenBases(charm, targetTrack, targetChannel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
+            }
+            const { mappings } = charmcraftStatus[trackIndex];
+            const validBases = mappings
+                .filter((mapping) => mapping.base &&
+                mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
+                    release.status === 'open'))
+                .map((mapping) => mapping.base);
+            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            return validBases;
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42999,7 +42999,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });
@@ -43106,12 +43106,20 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             const { mappings } = charmcraftStatus[trackIndex];
+            const allBases = mappings.map((mapping) => mapping.base);
             const validBases = mappings
                 .filter((mapping) => mapping.base &&
                 mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
                     release.status === 'open'))
                 .map((mapping) => mapping.base);
-            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            // Determine bases that were filtered out
+            const filteredOutBases = allBases.filter((base) => !validBases.some((validBase) => validBase.name === base.name &&
+                validBase.channel === base.channel &&
+                validBase.architecture === base.architecture));
+            if (filteredOutBases.length > 0) {
+                core.warning(`Filtered out bases that are not open for ${targetTrack}/${targetChannel}: ${JSON.stringify(filteredOutBases, null, 2)}`);
+            }
+            core.info(`Filtered bases that are open for ${targetTrack}/${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
             return validBases;
         });
     }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -42908,7 +42908,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43107,6 +43107,24 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             return charmcraftStatus[trackIndex].mappings.map((x) => x.base);
+        });
+    }
+    getOpenBases(charm, targetTrack, targetChannel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
+            }
+            const { mappings } = charmcraftStatus[trackIndex];
+            const validBases = mappings
+                .filter((mapping) => mapping.base &&
+                mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
+                    release.status === 'open'))
+                .map((mapping) => mapping.base);
+            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            return validBases;
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -43011,7 +43011,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });
@@ -43118,12 +43118,20 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             const { mappings } = charmcraftStatus[trackIndex];
+            const allBases = mappings.map((mapping) => mapping.base);
             const validBases = mappings
                 .filter((mapping) => mapping.base &&
                 mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
                     release.status === 'open'))
                 .map((mapping) => mapping.base);
-            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            // Determine bases that were filtered out
+            const filteredOutBases = allBases.filter((base) => !validBases.some((validBase) => validBase.name === base.name &&
+                validBase.channel === base.channel &&
+                validBase.architecture === base.architecture));
+            if (filteredOutBases.length > 0) {
+                core.warning(`Filtered out bases that are not open for ${targetTrack}/${targetChannel}: ${JSON.stringify(filteredOutBases, null, 2)}`);
+            }
+            core.info(`Filtered bases that are open for ${targetTrack}/${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
             return validBases;
         });
     }

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -43011,7 +43011,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -43142,7 +43142,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });
@@ -43249,12 +43249,20 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             const { mappings } = charmcraftStatus[trackIndex];
+            const allBases = mappings.map((mapping) => mapping.base);
             const validBases = mappings
                 .filter((mapping) => mapping.base &&
                 mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
                     release.status === 'open'))
                 .map((mapping) => mapping.base);
-            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            // Determine bases that were filtered out
+            const filteredOutBases = allBases.filter((base) => !validBases.some((validBase) => validBase.name === base.name &&
+                validBase.channel === base.channel &&
+                validBase.architecture === base.architecture));
+            if (filteredOutBases.length > 0) {
+                core.warning(`Filtered out bases that are not open for ${targetTrack}/${targetChannel}: ${JSON.stringify(filteredOutBases, null, 2)}`);
+            }
+            core.info(`Filtered bases that are open for ${targetTrack}/${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
             return validBases;
         });
     }

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -43039,7 +43039,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43238,6 +43238,24 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             return charmcraftStatus[trackIndex].mappings.map((x) => x.base);
+        });
+    }
+    getOpenBases(charm, targetTrack, targetChannel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
+            }
+            const { mappings } = charmcraftStatus[trackIndex];
+            const validBases = mappings
+                .filter((mapping) => mapping.base &&
+                mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
+                    release.status === 'open'))
+                .map((mapping) => mapping.base);
+            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            return validBases;
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -43142,7 +43142,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42887,7 +42887,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43086,6 +43086,24 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             return charmcraftStatus[trackIndex].mappings.map((x) => x.base);
+        });
+    }
+    getOpenBases(charm, targetTrack, targetChannel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
+            }
+            const { mappings } = charmcraftStatus[trackIndex];
+            const validBases = mappings
+                .filter((mapping) => mapping.base &&
+                mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
+                    release.status === 'open'))
+                .map((mapping) => mapping.base);
+            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            return validBases;
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42990,7 +42990,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });
@@ -43097,12 +43097,20 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             const { mappings } = charmcraftStatus[trackIndex];
+            const allBases = mappings.map((mapping) => mapping.base);
             const validBases = mappings
                 .filter((mapping) => mapping.base &&
                 mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
                     release.status === 'open'))
                 .map((mapping) => mapping.base);
-            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            // Determine bases that were filtered out
+            const filteredOutBases = allBases.filter((base) => !validBases.some((validBase) => validBase.name === base.name &&
+                validBase.channel === base.channel &&
+                validBase.architecture === base.architecture));
+            if (filteredOutBases.length > 0) {
+                core.warning(`Filtered out bases that are not open for ${targetTrack}/${targetChannel}: ${JSON.stringify(filteredOutBases, null, 2)}`);
+            }
+            core.info(`Filtered bases that are open for ${targetTrack}/${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
             return validBases;
         });
     }

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -42990,7 +42990,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -43030,7 +43030,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });
@@ -43137,12 +43137,20 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             const { mappings } = charmcraftStatus[trackIndex];
+            const allBases = mappings.map((mapping) => mapping.base);
             const validBases = mappings
                 .filter((mapping) => mapping.base &&
                 mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
                     release.status === 'open'))
                 .map((mapping) => mapping.base);
-            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            // Determine bases that were filtered out
+            const filteredOutBases = allBases.filter((base) => !validBases.some((validBase) => validBase.name === base.name &&
+                validBase.channel === base.channel &&
+                validBase.architecture === base.architecture));
+            if (filteredOutBases.length > 0) {
+                core.warning(`Filtered out bases that are not open for ${targetTrack}/${targetChannel}: ${JSON.stringify(filteredOutBases, null, 2)}`);
+            }
+            core.info(`Filtered bases that are open for ${targetTrack}/${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
             return validBases;
         });
     }

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -42927,7 +42927,7 @@ class Charmcraft {
               Revision    Created at    Size
               2 <- This   2022-01-20    1024B
               1           2021-07-19    512B
-              
+        
             */
             if (result.stdout.trim().split('\n').length <= 1) {
                 throw new Error(`Resource '${name}' does not have any uploaded revisions.`);
@@ -43126,6 +43126,24 @@ class Charmcraft {
                 throw new Error(`No track with name ${targetTrack}`);
             }
             return charmcraftStatus[trackIndex].mappings.map((x) => x.base);
+        });
+    }
+    getOpenBases(charm, targetTrack, targetChannel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Get status of this charm as a structured object
+            const charmcraftStatus = yield this.statusJson(charm);
+            const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);
+            if (trackIndex === -1) {
+                throw new Error(`No track with name ${targetTrack}`);
+            }
+            const { mappings } = charmcraftStatus[trackIndex];
+            const validBases = mappings
+                .filter((mapping) => mapping.base &&
+                mapping.releases.some((release) => release.channel === `${targetTrack}/${targetChannel}` &&
+                    release.status === 'open'))
+                .map((mapping) => mapping.base);
+            core.info(`Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`);
+            return validBases;
         });
     }
     release(charm, charmRevision, destinationChannel, resourceInfo) {

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -43030,7 +43030,7 @@ class Charmcraft {
     }
     statusJson(charm) {
         return __awaiter(this, void 0, void 0, function* () {
-            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], this.execOptions);
+            const result = yield (0, exec_1.getExecOutput)('charmcraft', ['status', charm, '--format', 'json'], Object.assign(Object.assign({}, this.execOptions), { silent: true }));
             const parsedObj = JSON.parse(result.stdout);
             return parsedObj;
         });

--- a/promote-charm/README.md
+++ b/promote-charm/README.md
@@ -1,6 +1,9 @@
 # canonical/charming-actions/promote-charm
 
-This action is used to promote an already uploaded charm to a different channel in charmhub. It is designed to be manually triggered with the inputs. The promotion involves all the existing bases for the charm.
+This action is used to promote an already uploaded charm to a different channel in charmhub. It is designed to be manually triggered with the inputs. The promotion involves all the existing combination of base/architecture for the charm.
+
+**Note**: It is necessary to have at least one release for a certain base/architecture in the `origin-channel`. E.g: if there isn't a release in `latest/candidate` for `ubuntu 20.04 (arm64)`, the action will igonore the promotion from `latest/candidate` to `latest/stable`.
+
 ## Usage
 
 ```yaml
@@ -45,11 +48,11 @@ In multi charm repo, you would also need to provide the charm path; this is nece
 ### Inputs
 
 | Key                  | Description                                                                                             | Required |
-| -------------------- | ------------------------------------------------------------------------------------------------------- | -------- | 
+| -------------------- | ------------------------------------------------------------------------------------------------------- | -------- |
 | `credentials`        | Credentials [exported](https://juju.is/docs/sdk/remote-env-auth) using `charmcraft login --export`.     | ✔️       |
 | `destination-channel`| Channel to which the charm will be released. It must be in the format of `track/risk`.                  | ✔️       |
 | `origin-channel`     | Origin Channel from where the charm that needs to be promoted will be pulled.                           | ✔️       |
-| `charm-path`         | Path to the charm where `metadata.yaml` is located. Defaults to the current working directory.          |          |    
+| `charm-path`         | Path to the charm where `metadata.yaml` is located. Defaults to the current working directory.          |          |
 | `charmcraft-channel` | Snap channel to use when installing charmcraft. Defaults to `latest/edge`.                              |          |
 
 ### Outputs

--- a/src/actions/promote-charm/promote-charm.ts
+++ b/src/actions/promote-charm/promote-charm.ts
@@ -32,12 +32,8 @@ export class PromoteCharmAction {
     channel: string,
     bases: Base[],
   ): Promise<RevisionResourceInfo[]> {
-    // Filter out bases with architecture "all"
-    const filteredBases = bases.filter((base) => base.architecture !== 'all');
-
-    // Map filtered bases to their revision information
     return Promise.all(
-      filteredBases.map(async (base: Base) =>
+      bases.map(async (base: Base) =>
         this.charmcraft.getRevisionInfoFromChannelJson(
           name,
           track,
@@ -56,7 +52,11 @@ export class PromoteCharmAction {
 
       const [originTrack, originChannel] = this.originChannel.split('/');
 
-      const basesArray = await this.charmcraft.getBases(charmName, originTrack);
+      const basesArray = await this.charmcraft.getOpenBases(
+        charmName,
+        originTrack,
+        originChannel,
+      );
       const revisions = await this.getRevisions(
         charmName,
         originTrack,

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -289,7 +289,7 @@ class Charmcraft {
     const result = await getExecOutput(
       'charmcraft',
       ['status', charm, '--format', 'json'],
-      this.execOptions,
+      { ...this.execOptions, silent: true }, // Suppress auto-logging
     );
     const parsedObj = JSON.parse(result.stdout);
     return parsedObj;

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -166,7 +166,7 @@ class Charmcraft {
       Revision    Created at    Size
       2 <- This   2022-01-20    1024B
       1           2021-07-19    512B
-      
+
     */
 
     if (result.stdout.trim().split('\n').length <= 1) {
@@ -433,6 +433,42 @@ class Charmcraft {
     }
 
     return charmcraftStatus[trackIndex].mappings.map((x) => x.base);
+  }
+
+  async getOpenBases(
+    charm: string,
+    targetTrack: string,
+    targetChannel: string,
+  ): Promise<Base[]> {
+    // Get status of this charm as a structured object
+    const charmcraftStatus = await this.statusJson(charm);
+
+    const trackIndex = charmcraftStatus.findIndex(
+      (track: Track) => track.track === targetTrack,
+    );
+
+    if (trackIndex === -1) {
+      throw new Error(`No track with name ${targetTrack}`);
+    }
+
+    const { mappings } = charmcraftStatus[trackIndex];
+
+    const validBases = mappings
+      .filter(
+        (mapping) =>
+          mapping.base &&
+          mapping.releases.some(
+            (release) =>
+              release.channel === `${targetTrack}/${targetChannel}` &&
+              release.status === 'open',
+          ),
+      )
+      .map((mapping) => mapping.base);
+
+    core.info(
+      `Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`,
+    );
+    return validBases;
   }
 
   async release(

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -289,7 +289,7 @@ class Charmcraft {
     const result = await getExecOutput(
       'charmcraft',
       ['status', charm, '--format', 'json'],
-      { ...this.execOptions, silent: true }, // Suppress auto-logging
+      this.execOptions,
     );
     const parsedObj = JSON.parse(result.stdout);
     return parsedObj;
@@ -453,6 +453,8 @@ class Charmcraft {
 
     const { mappings } = charmcraftStatus[trackIndex];
 
+    const allBases = mappings.map((mapping) => mapping.base);
+
     const validBases = mappings
       .filter(
         (mapping) =>
@@ -465,8 +467,25 @@ class Charmcraft {
       )
       .map((mapping) => mapping.base);
 
+    // Determine bases that were filtered out
+    const filteredOutBases = allBases.filter(
+      (base) =>
+        !validBases.some(
+          (validBase) =>
+            validBase.name === base.name &&
+            validBase.channel === base.channel &&
+            validBase.architecture === base.architecture,
+        ),
+    );
+
+    if (filteredOutBases.length > 0) {
+      core.warning(
+        `Filtered out bases that are not open for ${targetTrack}/${targetChannel}: ${JSON.stringify(filteredOutBases, null, 2)}`,
+      );
+    }
+
     core.info(
-      `Filtered bases that is open for ${targetChannel}: ${JSON.stringify(validBases, null, 2)}`,
+      `Filtered bases that are open for ${targetTrack}/${targetChannel}: ${JSON.stringify(validBases, null, 2)}`,
     );
     return validBases;
   }


### PR DESCRIPTION
Some old projects doesn't have all channels open and the current implementation is too strict  about this by throwing errors. #153 did this for older charms that used to have the `all` architecture, but this issue also happens for other scenarios. E.g:
- Charm ubuntu 16.04 (riscv64) has the channel latest/edge closed for prometheus-libvirt-exporter, but for some reason it has open for the stable:
```
         ubuntu 16.04 (riscv64)  stable     7                  7           -
                                 candidate  ↑                  ↑           ↑
                                 beta       ↑                  ↑           ↑
                                 edge       ↑                  ↑           ↑
```

This change filters only the base-arch combinations that have the target track/channel open, so it doesn't block all the releases.