### PR TITLE
fix(promote-charm): support channel branches

### DIFF
--- a/dist/channel/index.js
+++ b/dist/channel/index.js
@@ -42971,10 +42971,6 @@ class Charmcraft {
     }
     getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
-            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(targetChannel)) {
-                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
-            }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);

--- a/dist/check-libraries/index.js
+++ b/dist/check-libraries/index.js
@@ -43166,10 +43166,6 @@ class Charmcraft {
     }
     getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
-            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(targetChannel)) {
-                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
-            }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);

--- a/dist/promote-charm/index.js
+++ b/dist/promote-charm/index.js
@@ -42530,7 +42530,8 @@ class PromoteCharmAction {
                 yield this.snap.install('charmcraft', this.charmcraftChannel);
                 process.chdir(this.charmPath);
                 const charmName = this.charmcraft.charmName();
-                const [originTrack, originChannel] = this.originChannel.split('/');
+                const [originTrack, ...originChannelParts] = this.originChannel.split('/');
+                const originChannel = originChannelParts.join('/');
                 const basesArray = yield this.charmcraft.getOpenBases(charmName, originTrack, originChannel);
                 const revisions = yield this.getRevisions(charmName, originTrack, originChannel, basesArray);
                 yield Promise.all(revisions.map(({ charmRev, resources }) => __awaiter(this, void 0, void 0, function* () {
@@ -43050,10 +43051,6 @@ class Charmcraft {
     }
     getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
-            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(targetChannel)) {
-                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
-            }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);

--- a/dist/release-charm/index.js
+++ b/dist/release-charm/index.js
@@ -43062,10 +43062,6 @@ class Charmcraft {
     }
     getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
-            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(targetChannel)) {
-                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
-            }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);

--- a/dist/release-libraries/index.js
+++ b/dist/release-libraries/index.js
@@ -43193,10 +43193,6 @@ class Charmcraft {
     }
     getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
-            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(targetChannel)) {
-                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
-            }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);

--- a/dist/upload-bundle/index.js
+++ b/dist/upload-bundle/index.js
@@ -43041,10 +43041,6 @@ class Charmcraft {
     }
     getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
-            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(targetChannel)) {
-                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
-            }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);

--- a/dist/upload-charm/index.js
+++ b/dist/upload-charm/index.js
@@ -43081,10 +43081,6 @@ class Charmcraft {
     }
     getRevisionInfoFromChannelJson(charm, targetTrack, targetChannel, targetBase) {
         return __awaiter(this, void 0, void 0, function* () {
-            const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-            if (!acceptedChannels.includes(targetChannel)) {
-                throw new Error(`Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`);
-            }
             // Get status of this charm as a structured object
             const charmcraftStatus = yield this.statusJson(charm);
             const trackIndex = charmcraftStatus.findIndex((track) => track.track === targetTrack);

--- a/src/actions/promote-charm/promote-charm.ts
+++ b/src/actions/promote-charm/promote-charm.ts
@@ -50,7 +50,9 @@ export class PromoteCharmAction {
       process.chdir(this.charmPath!);
       const charmName = this.charmcraft.charmName();
 
-      const [originTrack, originChannel] = this.originChannel.split('/');
+      const [originTrack, ...originChannelParts] =
+        this.originChannel.split('/');
+      const originChannel = originChannelParts.join('/');
 
       const basesArray = await this.charmcraft.getOpenBases(
         charmName,

--- a/src/services/charmcraft/charmcraft.test.ts
+++ b/src/services/charmcraft/charmcraft.test.ts
@@ -553,32 +553,129 @@ describe('the charmcraft service', () => {
         );
         expect(result).toEqual(expected);
       });
-    });
 
-    describe('throws correct error', () => {
-      it('when an invalid channel was provided', async () => {
+      it('with branch channel', async () => {
+        const charmcraftStatus = [
+          {
+            track: 'latest',
+            mappings: [
+              {
+                base: {
+                  name: 'ubuntu',
+                  channel: '20.04',
+                  architecture: 'amd64',
+                },
+                releases: [
+                  {
+                    status: 'closed',
+                    channel: 'latest/stable',
+                    version: null,
+                    revision: null,
+                    resources: null,
+                    expires_at: null,
+                  },
+                  {
+                    status: 'open',
+                    channel: 'latest/candidate',
+                    version: '3',
+                    revision: 3,
+                    resources: [
+                      {
+                        name: 'httpbin-image',
+                        revision: 3,
+                      },
+                    ],
+                    expires_at: null,
+                  },
+                  {
+                    status: 'open',
+                    channel: 'latest/beta',
+                    version: '10',
+                    revision: 10,
+                    resources: [
+                      {
+                        name: 'httpbin-image',
+                        revision: 10,
+                      },
+                    ],
+                    expires_at: null,
+                  },
+                  {
+                    status: 'open',
+                    channel: 'latest/edge',
+                    version: '10',
+                    revision: 10,
+                    resources: [
+                      {
+                        name: 'httpbin-image',
+                        revision: 10,
+                      },
+                    ],
+                    expires_at: null,
+                  },
+                  {
+                    status: 'open',
+                    channel: 'latest/beta/feature-123',
+                    version: '13',
+                    revision: 13,
+                    resources: [
+                      {
+                        name: 'httpbin-image',
+                        revision: 13,
+                      },
+                    ],
+                    expires_at: '2025-01-01T00:00:00z',
+                  },
+                  {
+                    status: 'open',
+                    channel: 'latest/edge/feature-123',
+                    version: '15',
+                    revision: 15,
+                    resources: [
+                      {
+                        name: 'httpbin-image',
+                        revision: 15,
+                      },
+                    ],
+                    expires_at: '2025-01-01T00:00:00z',
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const track = 'latest';
+        const channel = 'edge/feature-123';
         const base = {
           name: 'ubuntu',
           channel: '20.04',
           architecture: 'amd64',
         };
+        const expected = {
+          charmRev: '15',
+          resources: [{ resourceName: 'httpbin-image', resourceRev: '15' }],
+        };
 
         const charmcraft = new Charmcraft('token');
 
-        await expect(
-          charmcraft.getRevisionInfoFromChannelJson(
-            'placeholder-charm',
-            'valid track',
-            'invalid-channel',
-            base,
-          ),
-        ).rejects.toThrow(
-          Error(
-            `Provided channel invalid-channel is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`,
-          ),
-        );
-      });
+        jest.spyOn(exec, 'getExecOutput').mockResolvedValue({
+          exitCode: 0,
+          stderr: '',
+          stdout: JSON.stringify(charmcraftStatus),
+        });
 
+        const result = await charmcraft.getRevisionInfoFromChannelJson(
+          'placeholder-charm',
+          track,
+          channel,
+          base,
+        );
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('throws correct error', () => {
       it('when track not found', async () => {
         const charmcraftStatus = [{ track: 'special-track' }];
         const track = 'latest';

--- a/src/services/charmcraft/charmcraft.ts
+++ b/src/services/charmcraft/charmcraft.ts
@@ -351,13 +351,6 @@ class Charmcraft {
     targetChannel: string,
     targetBase: Base,
   ): Promise<RevisionResourceInfo> {
-    const acceptedChannels = ['stable', 'candidate', 'beta', 'edge'];
-    if (!acceptedChannels.includes(targetChannel)) {
-      throw new Error(
-        `Provided channel ${targetChannel} is not supported. This actions currently only works with one of the following default channels: edge, beta, candidate, stable`,
-      );
-    }
-
     // Get status of this charm as a structured object
     const charmcraftStatus = await this.statusJson(charm);
 


### PR DESCRIPTION
Small change to allow channel branches (eg `edge/feature-123`) to be used with the `promote-charm` action.

This seems to have originally been excluded prior to JSON support for `charmcraft status` was added. Since this feature is now available, the channel whitelist in `getRevisionInfoFromChannelJson` can be removed.

I removed the test that was checking an 'invalid channel' error was thrown, replacing it with a test that ensures the status is correctly parsed with a channel containing a branch.

Thanks!