### PR TITLE
ci: run JavaScript actions on Node 24

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install dependencies
         run: |
           npm install
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install dependencies
         run: |
           npm install
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install dependencies
         run: |
           npm install

--- a/channel/action.yaml
+++ b/channel/action.yaml
@@ -3,7 +3,7 @@ description: |
   Selects which channel a charm should be uploaded to based on git context
 author: Simon Aronsson
 runs:
-  using: node20
+  using: node24
   main: ../dist/channel/index.js
 branding:
   icon: upload-cloud

--- a/check-libraries/action.yaml
+++ b/check-libraries/action.yaml
@@ -8,7 +8,7 @@ branding:
   color: orange
 
 runs:
-  using: node20
+  using: node24
   main: ../dist/check-libraries/index.js
 
 inputs:

--- a/promote-charm/action.yaml
+++ b/promote-charm/action.yaml
@@ -27,7 +27,7 @@ inputs:
       Credentials exported from `charmcraft login --export`. See
       https://juju.is/docs/sdk/remote-env-auth for more info
 runs:
-  using: node20
+  using: node24
   main: ../dist/promote-charm/index.js
 branding:
   icon: upload-cloud

--- a/release-charm/action.yaml
+++ b/release-charm/action.yaml
@@ -51,7 +51,7 @@ inputs:
     description: |
       Github Token needed for updating Release Information
 runs:
-  using: node20
+  using: node24
   main: ../dist/release-charm/index.js
 branding:
   icon: upload-cloud

--- a/release-libraries/action.yaml
+++ b/release-libraries/action.yaml
@@ -27,7 +27,7 @@ inputs:
     description: >
       Whether to fail the entire build if publishing lib fails for any reason.
 runs:
-  using: node20
+  using: node24
   main: ../dist/release-libraries/index.js
 branding:
   icon: upload-cloud

--- a/upload-bundle/action.yaml
+++ b/upload-bundle/action.yaml
@@ -32,7 +32,7 @@ inputs:
     description: |
       Github Token needed for automatic tagging when publishing
 runs:
-  using: node20
+  using: node24
   main: ../dist/upload-bundle/index.js
 branding:
   icon: upload-cloud

--- a/upload-charm/action.yaml
+++ b/upload-charm/action.yaml
@@ -72,7 +72,7 @@ inputs:
 
       Example: "promql-transform:2,prometheus-image:12"
 runs:
-  using: node20
+  using: node24
   main: ../dist/upload-charm/index.js
 branding:
   icon: upload-cloud


### PR DESCRIPTION
## Summary
- Update JavaScript action metadata from `node20` to `node24` for all bundled actions.
- Update the repository CI setup-node version to Node.js 24 so tests/builds exercise the runtime GitHub will force from 2026-06-16.

## Context
GitHub Actions now warns that Node.js 20 JavaScript actions are deprecated and will be forced to Node.js 24 by default on 2026-06-16, then removed from runners on 2026-09-16. This affects downstream users of `canonical/charming-actions/check-libraries@2.7.0` and the other JavaScript actions in this repository.

## Verification
- `GITHUB_REPOSITORY=canonical/charming-actions mise exec node@24 -- npm run test`
- `mise exec node@24 -- npm run format`
- `mise exec node@24 -- npm run lint`
- `mise exec node@24 -- npm run build`
